### PR TITLE
Fix: Improve Bluetooth connection status monitoring

### DIFF
--- a/sendspin_client.py
+++ b/sendspin_client.py
@@ -91,9 +91,29 @@ class BluetoothManager:
     
     def is_device_connected(self) -> bool:
         """Check if device is currently connected"""
-        success, output = self._run_bluetoothctl(['info', self.mac_address])
-        self.connected = success and 'Connected: yes' in output
-        return self.connected
+        try:
+            # Use subprocess directly for more reliable real-time status
+            result = subprocess.run(
+                ['bluetoothctl', 'info', self.mac_address],
+                capture_output=True,
+                text=True,
+                timeout=5
+            )
+            is_connected = result.returncode == 0 and 'Connected: yes' in result.stdout
+            
+            # Log status changes
+            if is_connected != self.connected:
+                if is_connected:
+                    logger.info(f"✓ Bluetooth device {self.mac_address} connected")
+                else:
+                    logger.warning(f"✗ Bluetooth device {self.mac_address} disconnected")
+            
+            self.connected = is_connected
+            return self.connected
+        except Exception as e:
+            logger.debug(f"Error checking Bluetooth connection: {e}")
+            self.connected = False
+            return False
     
     def pair_device(self) -> bool:
         """Pair with the Bluetooth device"""
@@ -332,10 +352,12 @@ class SendspinClient:
     
     async def update_status(self):
         """Update client status"""
+        logger.debug("Status monitoring loop started")
         while self.running:
             try:
                 if self.bt_manager:
                     bt_connected = self.bt_manager.is_device_connected()
+                    logger.debug(f"Bluetooth status check: connected={bt_connected}")
                     if bt_connected != self.status['bluetooth_connected']:
                         self.status['bluetooth_connected'] = bt_connected
                         self.status['bluetooth_connected_at'] = datetime.now().isoformat()


### PR DESCRIPTION
## Problem
The Bluetooth connection status was not being accurately monitored or updated. When the Bluetooth speaker was disconnected, the web UI and API continued to show it as connected indefinitely.

## Root Cause
The `is_device_connected()` method was using a piped `bluetoothctl` command approach (`echo 'info MAC' | bluetoothctl`) which was unreliable for real-time status monitoring.

## Solution
Improved the Bluetooth status monitoring system:

1. **Direct subprocess execution**: Changed `is_device_connected()` to use direct `subprocess.run(['bluetoothctl', 'info', MAC])` for more reliable real-time status checks
2. **Connection state logging**: Added automatic logging when Bluetooth devices connect/disconnect
3. **Debug logging**: Added status check logging to help troubleshoot monitoring issues
4. **Improved error handling**: Better exception handling with debug-level logging

## Testing
✅ Tested with speaker disconnected - correctly shows `bluetooth_connected: false` in API  
✅ Log message confirms: "✗ Bluetooth device 04:57:91:D8:EC:9D disconnected"  
✅ Status updates within 10 seconds of actual disconnection  
✅ Web UI reflects correct connection state

## Changes
- Modified `is_device_connected()` method in `BluetoothManager` class
- Added connection state change logging (INFO for connect, WARNING for disconnect)  
- Added debug logging to `update_status()` monitoring loop
- Improved timeout handling (5 seconds for status checks)