### PR TITLE
Add Proxmox VE (LXC) deployment support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ config.json
 .pytest_cache/
 .coverage
 htmlcov/
+
+# Worktrees
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -23,115 +23,23 @@ A Docker-based Sendspin client with Bluetooth speaker support and web-based conf
 
 ## Proxmox VE (LXC) Deployment
 
-Run Sendspin Client as a **native LXC container** on Proxmox VE — no Docker required. The LXC container runs its own `bluetoothd`, `pulseaudio`, and `avahi-daemon`, with USB Bluetooth hardware passed through via cgroup rules.
+Run Sendspin Client as a **native LXC container** on Proxmox VE — no Docker required. The LXC container uses the **host's `bluetoothd` via a D-Bus bridge** (AF_BLUETOOTH is not available in LXC namespaces), with `pulseaudio --system` and `avahi-daemon` running inside the container.
 
-### Docker vs LXC comparison
+For full documentation, prerequisites, manual install steps, pairing instructions, and monitoring commands, see **[lxc/README.md](lxc/README.md)**.
 
-| Feature | Docker | LXC (Proxmox) |
-|---------|--------|---------------|
-| Deployment target | Any Docker host | Proxmox VE 7/8 |
-| Bluetooth | Uses host's bluetoothd via D-Bus socket | Own bluetoothd inside container |
-| Audio | Uses host's PulseAudio/PipeWire socket | Own pulseaudio --system inside container |
-| mDNS discovery | Uses host's avahi-daemon | Own avahi-daemon inside container |
-| Config changes | Container restart | `systemctl restart sendspin-client` |
-| USB BT adapter | Host passthrough | cgroup passthrough to LXC |
-
-### One-line install (on Proxmox host as root)
+### Quick install (on Proxmox host as root)
 
 ```bash
 bash <(curl -fsSL https://raw.githubusercontent.com/loryanstrant/sendspin-client/main/lxc/proxmox-create.sh)
 ```
 
-The script will interactively prompt for container ID, hostname, RAM, disk, network, and USB Bluetooth passthrough options.
-
-### Prerequisites
-
-- Proxmox VE 7 or 8
-- USB Bluetooth adapter (or onboard Bluetooth on the Proxmox host)
-- Debian 12 LXC template available in Proxmox (the script downloads it automatically)
-
-### Manual install steps (Proxmox UI)
-
-If you prefer to create the container via the Proxmox web UI:
-
-1. Create a new **privileged** LXC container (Debian 12, 512 MB RAM, 4 GB disk)
-2. Start the container and open a shell (`pct enter <CTID>`)
-3. Run the installer:
-   ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/loryanstrant/sendspin-client/main/lxc/install.sh)
-   ```
-4. Append the following to `/etc/pve/lxc/<CTID>.conf` on the **Proxmox host**:
-   ```
-   lxc.cgroup2.devices.allow: c 166:* rwm
-   lxc.cgroup2.devices.allow: c 13:* rwm
-   lxc.mount.entry: /dev/bus/usb dev/bus/usb none bind,optional,create=dir 0 0
-   # If using a USB Bluetooth adapter:
-   lxc.cgroup2.devices.allow: c 189:* rwm
-   ```
-5. Restart the container: `pct restart <CTID>`
-
-### Bluetooth speaker pairing (inside the container)
+Or download and review first:
 
 ```bash
-# Enter the container
-pct enter <CTID>
-
-# Start interactive Bluetooth manager
-bluetoothctl
-
-# Inside bluetoothctl:
-power on
-scan on
-# Wait for your speaker to appear, then:
-pair XX:XX:XX:XX:XX:XX
-trust XX:XX:XX:XX:XX:XX
-connect XX:XX:XX:XX:XX:XX
-exit
+curl -fsSL https://raw.githubusercontent.com/loryanstrant/sendspin-client/main/lxc/proxmox-create.sh -o proxmox-create.sh
+less proxmox-create.sh
+bash proxmox-create.sh
 ```
-
-Then set `BLUETOOTH_MAC` in `/config/config.json` and restart the service.
-
-### Key monitoring commands
-
-```bash
-# View application logs
-pct exec <CTID> -- journalctl -u sendspin-client -f
-
-# Check all service statuses
-pct exec <CTID> -- systemctl status sendspin-client pulseaudio-system bluetooth avahi-daemon --no-pager
-
-# List audio sinks (confirm Bluetooth sink is present)
-pct exec <CTID> -- pactl list sinks short
-
-# Check Bluetooth adapter
-pct exec <CTID> -- bluetoothctl show
-
-# Verify PulseAudio socket
-pct exec <CTID> -- ls -la /var/run/pulse/native
-```
-
-### Manual USB Bluetooth passthrough
-
-To pass through a specific USB Bluetooth adapter, find its device numbers on the Proxmox host:
-
-```bash
-lsusb | grep -i bluetooth
-# Example output: Bus 001 Device 003: ID 0a12:0001 Cambridge Silicon Radio, Ltd Bluetooth Dongle
-
-# Map Bus 001 Device 003 → /dev/bus/usb/001/003
-```
-
-Then add to `/etc/pve/lxc/<CTID>.conf`:
-```
-lxc.cgroup2.devices.allow: c 189:* rwm
-lxc.mount.entry: /dev/bus/usb dev/bus/usb none bind,optional,create=dir 0 0
-```
-
-> **Note:** Configuration changes in `/config/config.json` take effect after:
-> ```bash
-> pct exec <CTID> -- systemctl restart sendspin-client
-> ```
-> There is no need to restart the container.
 
 ---
 

--- a/lxc/README.md
+++ b/lxc/README.md
@@ -1,0 +1,160 @@
+# Sendspin Client — Proxmox VE LXC Deployment
+
+Run Sendspin Client as a **native LXC container** on Proxmox VE — no Docker required.
+
+## Architecture
+
+The LXC container **cannot** run its own `bluetoothd` due to `AF_BLUETOOTH` kernel namespace restrictions in LXC. Instead:
+
+- `bluetoothd` runs on the **Proxmox host**
+- The host's D-Bus socket (`/run/dbus`) is bind-mounted into the container at `/bt-dbus`
+- `pulseaudio --system` runs inside the container and connects to the host's BlueZ via this D-Bus bridge
+- `btctl` (installed wrapper) invokes `bluetoothctl` pointed at the correct `DBUS_SYSTEM_BUS_ADDRESS`
+
+## Docker vs LXC comparison
+
+| Feature | Docker | LXC (Proxmox) |
+|---------|--------|---------------|
+| Deployment target | Any Docker host | Proxmox VE 7/8 |
+| Bluetooth | Uses host's bluetoothd via D-Bus socket | Uses host's bluetoothd via D-Bus socket (`/bt-dbus`) |
+| Audio | Uses host's PulseAudio/PipeWire socket | Own `pulseaudio --system` inside container |
+| mDNS discovery | Uses host's avahi-daemon | Own avahi-daemon inside container |
+| Config changes | Container restart | `systemctl restart sendspin-client` |
+| USB BT adapter | Host passthrough | cgroup passthrough to LXC |
+
+## Prerequisites
+
+- Proxmox VE 7 or 8
+- USB Bluetooth adapter (or onboard Bluetooth on the Proxmox host)
+- **Ubuntu 24.04** LXC template available in Proxmox (the script downloads it automatically)
+
+## Quick Install
+
+### Option 1: One-line (on Proxmox host as root)
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/loryanstrant/sendspin-client/main/lxc/proxmox-create.sh)
+```
+
+### Option 2: Download and review first (recommended)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/loryanstrant/sendspin-client/main/lxc/proxmox-create.sh -o proxmox-create.sh
+# Review the script before running:
+less proxmox-create.sh
+bash proxmox-create.sh
+```
+
+The script interactively prompts for container ID, hostname, RAM, disk, network, and USB Bluetooth passthrough options.
+
+## Manual Install (via Proxmox Web UI)
+
+If you prefer to create the container via the Proxmox web UI:
+
+1. Create a new **privileged** LXC container (**Ubuntu 24.04**, 512 MB RAM, 4 GB disk)
+2. Start the container and open a shell (`pct enter <CTID>`)
+3. Run the installer:
+
+   **Option A — one-liner:**
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/loryanstrant/sendspin-client/main/lxc/install.sh)
+   ```
+
+   **Option B — download and review:**
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/loryanstrant/sendspin-client/main/lxc/install.sh -o install.sh
+   less install.sh
+   bash install.sh
+   ```
+
+4. Append the following to `/etc/pve/lxc/<CTID>.conf` on the **Proxmox host**:
+   ```
+   # AppArmor: unconfined (required for bluetoothd management socket in LXC)
+   lxc.apparmor.profile: unconfined
+   # Bluetooth HCI devices
+   lxc.cgroup2.devices.allow: c 166:* rwm
+   # Input devices
+   lxc.cgroup2.devices.allow: c 13:* rwm
+   # rfkill device (required by bluetoothd)
+   lxc.cgroup2.devices.allow: c 10:232 rwm
+   # Host D-Bus socket — gives PulseAudio and btctl access to the host's bluetoothd
+   lxc.mount.entry: /run/dbus bt-dbus none bind,create=dir 0 0
+   # USB devices (if using a USB Bluetooth adapter — grants access to all USB devices)
+   lxc.cgroup2.devices.allow: c 189:* rwm
+   ```
+
+5. Restart the container: `pct restart <CTID>`
+
+## Bluetooth Speaker Pairing
+
+Bluetooth runs on the **Proxmox host**. The `btctl` wrapper inside the container routes commands to the host's `bluetoothd` via the D-Bus bridge.
+
+```bash
+# Enter the container
+pct enter <CTID>
+
+# Start interactive Bluetooth manager (uses host's bluetoothd via D-Bus bridge)
+btctl
+
+# Inside btctl:
+power on
+scan on
+# Wait for your speaker to appear, then:
+pair XX:XX:XX:XX:XX:XX
+trust XX:XX:XX:XX:XX:XX
+connect XX:XX:XX:XX:XX:XX
+exit
+```
+
+Then set `BLUETOOTH_MAC` in `/config/config.json` and restart the service:
+
+```bash
+systemctl restart sendspin-client
+```
+
+## Monitoring
+
+```bash
+# View application logs
+pct exec <CTID> -- journalctl -u sendspin-client -f
+
+# Check service statuses
+# Note: bluetooth.service is intentionally disabled inside the container
+pct exec <CTID> -- systemctl status sendspin-client pulseaudio-system avahi-daemon --no-pager
+
+# List audio sinks (confirm Bluetooth sink is present)
+pct exec <CTID> -- pactl list sinks short
+
+# Check Bluetooth adapter (via host D-Bus bridge)
+pct exec <CTID> -- btctl show
+
+# Verify PulseAudio socket
+pct exec <CTID> -- ls -la /var/run/pulse/native
+```
+
+## Manual USB Bluetooth Passthrough
+
+To pass through a specific USB Bluetooth adapter, find its device numbers on the Proxmox host:
+
+```bash
+lsusb | grep -i bluetooth
+# Example output: Bus 001 Device 003: ID 0a12:0001 Cambridge Silicon Radio, Ltd Bluetooth Dongle
+
+# Map Bus 001 Device 003 → /dev/bus/usb/001/003
+```
+
+Then add to `/etc/pve/lxc/<CTID>.conf`:
+```
+lxc.cgroup2.devices.allow: c 189:* rwm
+lxc.mount.entry: /dev/bus/usb dev/bus/usb none bind,optional,create=dir 0 0
+```
+
+> **Note:** `c 189:* rwm` grants access to **all** USB devices in the LXC.
+> For tighter control, identify the specific USB device bus/device number with `lsusb` and restrict accordingly.
+
+## Notes
+
+- `bluetooth.service` is intentionally **disabled** inside the container — the host's `bluetoothd` is used instead
+- `btctl` is a wrapper for `bluetoothctl` that sets `DBUS_SYSTEM_BUS_ADDRESS` to the bind-mounted host socket at `/bt-dbus`
+- Config changes in `/config/config.json` take effect after `systemctl restart sendspin-client` (no container restart needed)
+- The privileged container and `lxc.apparmor.profile: unconfined` are required for Bluetooth hardware passthrough; hardening further would require upstream PVE support for AppArmor profiles that permit Bluetooth management sockets

--- a/lxc/install.sh
+++ b/lxc/install.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# install.sh - Sendspin Client LXC installer
+# Runs inside the LXC container as root. Idempotent (safe to re-run).
+# Usage: bash install.sh [--repo owner/repo] [--branch name]
+
+set -euo pipefail
+
+# ─── Colours ──────────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+BLUE='\033[0;34m'; CYAN='\033[0;36m'; BOLD='\033[1m'; NC='\033[0m'
+
+msg()  { echo -e "${CYAN}${BOLD}[Sendspin]${NC} $*"; }
+ok()   { echo -e "${GREEN}✓${NC} $*"; }
+warn() { echo -e "${YELLOW}⚠${NC}  $*"; }
+err()  { echo -e "${RED}✗${NC}  $*" >&2; }
+die()  { err "$*"; exit 1; }
+
+# ─── Argument parsing ─────────────────────────────────────────────────────────
+GITHUB_REPO="loryanstrant/sendspin-client"
+GITHUB_BRANCH="main"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)   GITHUB_REPO="$2";   shift 2 ;;
+    --branch) GITHUB_BRANCH="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+BASE="https://raw.githubusercontent.com/${GITHUB_REPO}/${GITHUB_BRANCH}"
+
+# ─── Pre-flight ───────────────────────────────────────────────────────────────
+[[ $EUID -eq 0 ]] || die "Must be run as root"
+
+msg "Sendspin Client LXC Installer"
+msg "Repo: ${GITHUB_REPO}  Branch: ${GITHUB_BRANCH}"
+echo ""
+
+# ─── 1. System packages ───────────────────────────────────────────────────────
+msg "Installing system packages..."
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y -qq \
+  python3 python3-pip \
+  bluetooth bluez bluez-tools \
+  pulseaudio pulseaudio-module-bluetooth \
+  alsa-utils dbus \
+  avahi-daemon avahi-utils libnss-mdns \
+  curl wget ca-certificates git jq tzdata procps
+ok "System packages installed"
+
+# ─── 2. App directory and files from GitHub ───────────────────────────────────
+msg "Downloading application files from GitHub..."
+mkdir -p /opt/sendspin-client
+
+wget -q "${BASE}/sendspin_client.py" -O /opt/sendspin-client/sendspin_client.py
+wget -q "${BASE}/web_interface.py"   -O /opt/sendspin-client/web_interface.py
+wget -q "${BASE}/requirements.txt"   -O /opt/sendspin-client/requirements.txt
+chmod +x /opt/sendspin-client/sendspin_client.py
+ok "Application files downloaded"
+
+# ─── 3. Python dependencies ───────────────────────────────────────────────────
+msg "Installing Python dependencies..."
+pip3 install --break-system-packages -q -r /opt/sendspin-client/requirements.txt
+ok "Python dependencies installed"
+
+# ─── 4. Config directory ──────────────────────────────────────────────────────
+msg "Setting up config directory..."
+mkdir -p /config
+
+if [[ ! -f /config/config.json ]]; then
+  cat > /config/config.json <<'EOF'
+{
+  "SENDSPIN_NAME": "Sendspin-LXC",
+  "SENDSPIN_SERVER": "auto",
+  "BLUETOOTH_MAC": "",
+  "TZ": "UTC"
+}
+EOF
+  ok "Default config.json written to /config/config.json"
+else
+  ok "config.json already exists — skipping"
+fi
+
+# ─── 5. PulseAudio system user ────────────────────────────────────────────────
+msg "Setting up pulse system user..."
+if ! id pulse &>/dev/null; then
+  useradd --system --home-dir /var/run/pulse --shell /bin/false --comment "PulseAudio system user" pulse
+  ok "Created pulse system user"
+else
+  ok "pulse user already exists — skipping"
+fi
+
+usermod -aG bluetooth pulse 2>/dev/null || true
+usermod -aG audio    pulse 2>/dev/null || true
+
+mkdir -p /var/run/pulse
+chown pulse:pulse /var/run/pulse
+chmod 755 /var/run/pulse
+ok "pulse user configured (bluetooth + audio groups)"
+
+# ─── 6. PulseAudio system configuration ──────────────────────────────────────
+msg "Writing PulseAudio system configuration..."
+mkdir -p /etc/pulse/client.conf.d
+
+cat > /etc/pulse/system.pa <<'EOF'
+# /etc/pulse/system.pa
+# PulseAudio system-mode configuration for Sendspin LXC deployment
+
+.ifexists module-udev-detect.so
+    load-module module-udev-detect
+.endif
+
+.ifexists module-bluetooth-policy.so
+    load-module module-bluetooth-policy
+.endif
+
+.ifexists module-bluetooth-discover.so
+    load-module module-bluetooth-discover
+.endif
+
+.ifexists module-native-protocol-unix.so
+    load-module module-native-protocol-unix auth-anonymous=1 socket=/var/run/pulse/native
+.endif
+
+.ifexists module-native-protocol-tcp.so
+    load-module module-native-protocol-tcp auth-ip-acl=127.0.0.1 auth-anonymous=1
+.endif
+
+.ifexists module-stream-restore.so
+    load-module module-stream-restore restore_device=false
+.endif
+
+.ifexists module-device-restore.so
+    load-module module-device-restore
+.endif
+
+.ifexists module-card-restore.so
+    load-module module-card-restore
+.endif
+EOF
+
+cat > /etc/pulse/client.conf.d/00-no-autospawn.conf <<'EOF'
+autospawn = no
+daemon-binary = /bin/true
+EOF
+
+ok "PulseAudio configuration written"
+
+# ─── 7. D-Bus policy for PulseAudio ↔ BlueZ ──────────────────────────────────
+msg "Writing D-Bus policy for PulseAudio Bluetooth access..."
+cat > /etc/dbus-1/system.d/pulseaudio-bluetooth.conf <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <policy user="pulse">
+    <allow own="org.pulseaudio.Server"/>
+    <allow send_destination="org.bluez"/>
+    <allow send_interface="org.bluez.MediaEndpoint1"/>
+    <allow send_interface="org.bluez.MediaTransport1"/>
+    <allow receive_sender="org.bluez"/>
+  </policy>
+  <policy context="default">
+    <allow send_destination="org.pulseaudio.Server"/>
+  </policy>
+</busconfig>
+EOF
+ok "D-Bus policy written"
+
+# ─── 8. Environment variables ─────────────────────────────────────────────────
+msg "Setting environment variables in /etc/environment..."
+
+set_env_var() {
+  local key="$1" val="$2"
+  if grep -q "^${key}=" /etc/environment 2>/dev/null; then
+    sed -i "s|^${key}=.*|${key}=${val}|" /etc/environment
+  else
+    echo "${key}=${val}" >> /etc/environment
+  fi
+}
+
+set_env_var "PULSE_SERVER"  "unix:/var/run/pulse/native"
+set_env_var "CONFIG_DIR"    "/config"
+set_env_var "WEB_PORT"      "8080"
+ok "Environment variables set"
+
+# ─── 9. Systemd units ─────────────────────────────────────────────────────────
+msg "Installing systemd service units..."
+
+cat > /etc/systemd/system/pulseaudio-system.service <<'EOF'
+[Unit]
+Description=PulseAudio System-Mode Daemon (Sendspin)
+After=dbus.service
+Requires=dbus.service
+Before=bluetooth.service sendspin-client.service
+
+[Service]
+Type=notify
+ExecStart=/usr/bin/pulseaudio --system --realtime --disallow-exit --no-cpu-limit --log-target=journal
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=5
+User=pulse
+Group=pulse
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+NoNewPrivileges=yes
+ProtectHome=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+RestrictNamespaces=yes
+RestrictRealtime=no
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat > /etc/systemd/system/sendspin-client.service <<'EOF'
+[Unit]
+Description=Sendspin Client (Music Assistant Player with Bluetooth)
+Documentation=https://github.com/loryanstrant/sendspin-client
+After=network-online.target dbus.service bluetooth.service pulseaudio-system.service avahi-daemon.service
+Wants=network-online.target
+Requires=pulseaudio-system.service dbus.service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+Environment=PYTHONUNBUFFERED=1
+ExecStartPre=/bin/sleep 3
+ExecStart=/usr/bin/python3 /opt/sendspin-client/sendspin_client.py
+WorkingDirectory=/opt/sendspin-client
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=sendspin-client
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+ok "Systemd units installed"
+
+# ─── 10. Enable and start services ───────────────────────────────────────────
+msg "Enabling and starting services..."
+systemctl daemon-reload
+
+for svc in dbus bluetooth avahi-daemon pulseaudio-system sendspin-client; do
+  systemctl enable "$svc" 2>/dev/null || warn "Could not enable $svc (may not exist yet)"
+done
+
+# Start in dependency order
+for svc in dbus bluetooth avahi-daemon pulseaudio-system sendspin-client; do
+  if systemctl is-active --quiet "$svc" 2>/dev/null; then
+    ok "$svc already running"
+  else
+    systemctl start "$svc" 2>/dev/null && ok "$svc started" || warn "$svc failed to start (check: journalctl -u $svc)"
+  fi
+done
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo -e "${GREEN}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${GREEN}${BOLD}  Sendspin Client installed successfully!${NC}"
+echo -e "${GREEN}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""
+
+# Detect container IP
+CONTAINER_IP=$(hostname -I 2>/dev/null | awk '{print $1}' || echo "<container-ip>")
+echo -e "  ${BOLD}Web UI:${NC}        http://${CONTAINER_IP}:8080"
+echo -e "  ${BOLD}Config file:${NC}   /config/config.json"
+echo -e "  ${BOLD}App logs:${NC}      journalctl -u sendspin-client -f"
+echo ""
+echo -e "  ${BOLD}Key commands:${NC}"
+echo -e "    systemctl status sendspin-client"
+echo -e "    systemctl restart sendspin-client"
+echo -e "    pactl list sinks short"
+echo -e "    bluetoothctl scan on"
+echo ""
+echo -e "  ${YELLOW}Note:${NC} Config changes require:"
+echo -e "    systemctl restart sendspin-client"
+echo ""

--- a/lxc/proxmox-create.sh
+++ b/lxc/proxmox-create.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# proxmox-create.sh - Create a Sendspin Client LXC container on Proxmox VE
+# Run as root on the Proxmox host.
+# Inspired by tteck/Proxmox community scripts.
+
+set -euo pipefail
+
+# ─── Colours & helpers ────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+BLUE='\033[0;34m'; CYAN='\033[0;36m'; BOLD='\033[1m'; NC='\033[0m'
+
+msg()    { echo -e "${CYAN}${BOLD}[Sendspin]${NC} $*"; }
+ok()     { echo -e "  ${GREEN}✓${NC} $*"; }
+warn()   { echo -e "  ${YELLOW}⚠${NC}  $*"; }
+err()    { echo -e "  ${RED}✗${NC}  $*" >&2; }
+die()    { err "$*"; exit 1; }
+prompt() { echo -e "  ${BLUE}?${NC}  $*"; }
+
+header() {
+  echo ""
+  echo -e "${CYAN}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+  echo -e "${CYAN}${BOLD}  Sendspin Client — Proxmox LXC Installer${NC}"
+  echo -e "${CYAN}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+  echo ""
+}
+
+spinner() {
+  local pid=$1 msg=${2:-"Working..."}
+  local frames=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏')
+  local i=0
+  while kill -0 "$pid" 2>/dev/null; do
+    printf "\r  ${CYAN}%s${NC}  %s" "${frames[$((i % ${#frames[@]}))]}" "$msg"
+    (( i++ )) || true
+    sleep 0.1
+  done
+  printf "\r%-60s\r" " "
+}
+
+ask() {
+  # ask VAR "Prompt" "default"
+  local var="$1" msg="$2" default="${3:-}"
+  if [[ -n "$default" ]]; then
+    prompt "${msg} [${BOLD}${default}${NC}]: "
+  else
+    prompt "${msg}: "
+  fi
+  read -r "$var" </dev/tty
+  if [[ -z "${!var}" && -n "$default" ]]; then
+    printf -v "$var" '%s' "$default"
+  fi
+}
+
+ask_yesno() {
+  local var="$1" msg="$2" default="${3:-y}"
+  local yn_display
+  if [[ "$default" == "y" ]]; then yn_display="Y/n"; else yn_display="y/N"; fi
+  prompt "${msg} [${BOLD}${yn_display}${NC}]: "
+  local answer
+  read -r answer </dev/tty
+  answer="${answer:-$default}"
+  if [[ "$answer" =~ ^[Yy] ]]; then printf -v "$var" 'y'; else printf -v "$var" 'n'; fi
+}
+
+# ─── Pre-flight checks ────────────────────────────────────────────────────────
+header
+
+msg "Running pre-flight checks..."
+
+[[ $EUID -eq 0 ]]         || die "Must be run as root"
+command -v pvesh &>/dev/null || die "pvesh not found — is this a Proxmox VE host?"
+command -v pct   &>/dev/null || die "pct not found — is this a Proxmox VE host?"
+command -v pveam &>/dev/null || die "pveam not found — is this a Proxmox VE host?"
+ok "Proxmox VE host confirmed"
+
+# ─── Interactive prompts ──────────────────────────────────────────────────────
+msg "Container configuration"
+echo ""
+
+# Next available CTID
+NEXT_ID=$(pvesh get /cluster/nextid 2>/dev/null || echo "100")
+
+ask CTID         "Container ID"                      "$NEXT_ID"
+ask HOSTNAME     "Hostname"                          "sendspin"
+ask RAM          "RAM (MB)"                          "512"
+ask DISK         "Disk size (GB)"                    "4"
+ask CORES        "CPU cores"                         "2"
+ask STORAGE      "Storage pool"                      "local-lvm"
+ask BRIDGE       "Network bridge"                    "vmbr0"
+ask IP           "IP address (CIDR, or 'dhcp')"      "dhcp"
+
+if [[ "$IP" != "dhcp" ]]; then
+  ask GATEWAY    "Gateway"                           ""
+fi
+
+ask GITHUB_REPO  "GitHub repo (owner/repo)"          "loryanstrant/sendspin-client"
+ask GITHUB_BRANCH "Branch"                           "main"
+
+ask_yesno USB_BT "Pass through USB Bluetooth adapter?" "y"
+
+echo ""
+warn "You will be prompted to set the LXC root password."
+echo ""
+
+# ─── Debian 12 template ───────────────────────────────────────────────────────
+msg "Checking for Debian 12 template..."
+
+TEMPLATE=$(pveam available --section system 2>/dev/null \
+  | grep "debian-12" | sort -V | tail -1 | awk '{print $2}')
+
+if [[ -z "$TEMPLATE" ]]; then
+  die "No Debian 12 template found in pveam. Run: pveam update"
+fi
+
+ok "Found template: ${TEMPLATE}"
+
+# Check if already downloaded
+if ! pveam list local 2>/dev/null | grep -q "$TEMPLATE"; then
+  msg "Downloading template ${TEMPLATE}..."
+  pveam update &>/dev/null &
+  spinner $! "Updating template list..."
+  pveam download local "$TEMPLATE" &
+  spinner $! "Downloading ${TEMPLATE}..."
+  wait
+  ok "Template downloaded"
+else
+  ok "Template already present"
+fi
+
+TEMPLATE_PATH="local:vztmpl/${TEMPLATE}"
+
+# ─── Create container ─────────────────────────────────────────────────────────
+msg "Creating LXC container ${CTID}..."
+
+NET_OPTS="name=eth0,bridge=${BRIDGE}"
+if [[ "$IP" == "dhcp" ]]; then
+  NET_OPTS="${NET_OPTS},ip=dhcp"
+else
+  NET_OPTS="${NET_OPTS},ip=${IP}"
+  if [[ -n "${GATEWAY:-}" ]]; then
+    NET_OPTS="${NET_OPTS},gw=${GATEWAY}"
+  fi
+fi
+
+pct create "$CTID" "$TEMPLATE_PATH" \
+  --hostname     "$HOSTNAME"        \
+  --memory       "$RAM"             \
+  --cores        "$CORES"           \
+  --rootfs       "${STORAGE}:${DISK}" \
+  --net0         "$NET_OPTS"        \
+  --unprivileged 0                  \
+  --features     nesting=1          \
+  --onboot       1                  \
+  --ostype       debian             \
+  --password \
+  2>&1
+
+ok "Container ${CTID} created"
+
+# ─── LXC config — cgroup rules & USB passthrough ─────────────────────────────
+msg "Adding cgroup device rules to container config..."
+
+LXC_CONF="/etc/pve/lxc/${CTID}.conf"
+
+cat >> "$LXC_CONF" <<'EOF'
+# Bluetooth HCI devices
+lxc.cgroup2.devices.allow: c 166:* rwm
+# Input devices
+lxc.cgroup2.devices.allow: c 13:* rwm
+# USB device tree (bind mount)
+lxc.mount.entry: /dev/bus/usb dev/bus/usb none bind,optional,create=dir 0 0
+EOF
+
+if [[ "${USB_BT}" == "y" ]]; then
+  cat >> "$LXC_CONF" <<'EOF'
+# USB devices (for USB Bluetooth adapter passthrough)
+lxc.cgroup2.devices.allow: c 189:* rwm
+EOF
+  ok "USB Bluetooth cgroup rules added"
+fi
+
+ok "cgroup device rules written to ${LXC_CONF}"
+
+# ─── Start container ──────────────────────────────────────────────────────────
+msg "Starting container ${CTID}..."
+pct start "$CTID"
+ok "Container started"
+
+msg "Waiting for container to be ready..."
+sleep 5
+
+# ─── Run install.sh inside container ─────────────────────────────────────────
+msg "Downloading install.sh from GitHub..."
+
+INSTALL_URL="https://raw.githubusercontent.com/${GITHUB_REPO}/${GITHUB_BRANCH}/lxc/install.sh"
+
+pct exec "$CTID" -- bash -c "curl -fsSL '${INSTALL_URL}' -o /root/install.sh 2>/dev/null || wget -q '${INSTALL_URL}' -O /root/install.sh"
+pct exec "$CTID" -- chmod +x /root/install.sh
+ok "install.sh downloaded into container"
+
+msg "Running install.sh inside container ${CTID}..."
+echo ""
+pct exec "$CTID" -- bash /root/install.sh --repo "$GITHUB_REPO" --branch "$GITHUB_BRANCH"
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo -e "${GREEN}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${GREEN}${BOLD}  LXC container created and configured!${NC}"
+echo -e "${GREEN}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""
+
+# Attempt to resolve container IP for summary
+CONTAINER_IP=$(pct exec "$CTID" -- hostname -I 2>/dev/null | awk '{print $1}' || echo "<container-ip>")
+
+echo -e "  ${BOLD}Container ID:${NC}   ${CTID}"
+echo -e "  ${BOLD}Hostname:${NC}       ${HOSTNAME}"
+echo -e "  ${BOLD}IP address:${NC}     ${CONTAINER_IP}"
+echo -e "  ${BOLD}Web UI:${NC}         http://${CONTAINER_IP}:8080"
+echo ""
+echo -e "  ${BOLD}Next steps:${NC}"
+echo -e "    1. Open the web UI and set your Bluetooth MAC address"
+echo -e "    2. Restart the service: ${CYAN}pct exec ${CTID} -- systemctl restart sendspin-client${NC}"
+echo ""
+echo -e "  ${BOLD}Useful commands:${NC}"
+echo -e "    # Enter the container:"
+echo -e "    ${CYAN}pct enter ${CTID}${NC}"
+echo ""
+echo -e "    # View logs:"
+echo -e "    ${CYAN}pct exec ${CTID} -- journalctl -u sendspin-client -f${NC}"
+echo ""
+echo -e "    # Pair a Bluetooth speaker:"
+echo -e "    ${CYAN}pct exec ${CTID} -- bluetoothctl${NC}"
+echo -e "    ${BLUE}  > scan on${NC}"
+echo -e "    ${BLUE}  > pair <MAC>${NC}"
+echo -e "    ${BLUE}  > trust <MAC>${NC}"
+echo -e "    ${BLUE}  > connect <MAC>${NC}"
+echo ""
+echo -e "  ${YELLOW}Note:${NC} Config changes → ${CYAN}pct exec ${CTID} -- systemctl restart sendspin-client${NC}"
+echo ""

--- a/lxc/pulse-system.pa
+++ b/lxc/pulse-system.pa
@@ -1,0 +1,35 @@
+# /etc/pulse/system.pa
+# PulseAudio system-mode configuration for Sendspin LXC deployment
+# Written by install.sh - do not edit manually
+
+.ifexists module-udev-detect.so
+    load-module module-udev-detect
+.endif
+
+.ifexists module-bluetooth-policy.so
+    load-module module-bluetooth-policy
+.endif
+
+.ifexists module-bluetooth-discover.so
+    load-module module-bluetooth-discover
+.endif
+
+.ifexists module-native-protocol-unix.so
+    load-module module-native-protocol-unix auth-anonymous=1 socket=/var/run/pulse/native
+.endif
+
+.ifexists module-native-protocol-tcp.so
+    load-module module-native-protocol-tcp auth-ip-acl=127.0.0.1 auth-anonymous=1
+.endif
+
+.ifexists module-stream-restore.so
+    load-module module-stream-restore restore_device=false
+.endif
+
+.ifexists module-device-restore.so
+    load-module module-device-restore
+.endif
+
+.ifexists module-card-restore.so
+    load-module module-card-restore
+.endif

--- a/lxc/pulse-system.pa
+++ b/lxc/pulse-system.pa
@@ -33,3 +33,9 @@
 .ifexists module-card-restore.so
     load-module module-card-restore
 .endif
+
+# Fallback null sink — used when no Bluetooth sink is available yet.
+# sendspin requires at least one sink to initialise.
+.ifexists module-null-sink.so
+    load-module module-null-sink sink_name=fallback rate=44100 channels=2
+.endif

--- a/lxc/pulseaudio-system.service
+++ b/lxc/pulseaudio-system.service
@@ -10,15 +10,10 @@ ExecStart=/usr/bin/pulseaudio --system --realtime --disallow-exit --no-cpu-limit
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartSec=5
-User=pulse
-Group=pulse
+Environment=PULSE_RUNTIME_PATH=/var/run/pulse
 LockPersonality=yes
-MemoryDenyWriteExecute=yes
-NoNewPrivileges=yes
-ProtectHome=yes
-ProtectKernelModules=yes
-ProtectKernelTunables=yes
-RestrictNamespaces=yes
+NoNewPrivileges=no
+ProtectHome=no
 RestrictRealtime=no
 
 [Install]

--- a/lxc/pulseaudio-system.service
+++ b/lxc/pulseaudio-system.service
@@ -6,6 +6,8 @@ Before=sendspin-client.service
 
 [Service]
 Type=notify
+User=pulse
+Group=pulse
 Environment=PULSE_RUNTIME_PATH=/var/run/pulse
 # Use the host's D-Bus socket (bind-mounted at /bt-dbus) for Bluetooth A2DP
 Environment=DBUS_SYSTEM_BUS_ADDRESS=unix:path=/bt-dbus/system_bus_socket
@@ -14,8 +16,7 @@ ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartSec=5
 LockPersonality=yes
-NoNewPrivileges=no
-ProtectHome=no
+NoNewPrivileges=yes
 RestrictRealtime=no
 
 [Install]

--- a/lxc/pulseaudio-system.service
+++ b/lxc/pulseaudio-system.service
@@ -2,15 +2,17 @@
 Description=PulseAudio System-Mode Daemon (Sendspin)
 After=dbus.service
 Requires=dbus.service
-Before=bluetooth.service sendspin-client.service
+Before=sendspin-client.service
 
 [Service]
 Type=notify
+Environment=PULSE_RUNTIME_PATH=/var/run/pulse
+# Use the host's D-Bus socket (bind-mounted at /bt-dbus) for Bluetooth A2DP
+Environment=DBUS_SYSTEM_BUS_ADDRESS=unix:path=/bt-dbus/system_bus_socket
 ExecStart=/usr/bin/pulseaudio --system --realtime --disallow-exit --no-cpu-limit --log-target=journal
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartSec=5
-Environment=PULSE_RUNTIME_PATH=/var/run/pulse
 LockPersonality=yes
 NoNewPrivileges=no
 ProtectHome=no

--- a/lxc/pulseaudio-system.service
+++ b/lxc/pulseaudio-system.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=PulseAudio System-Mode Daemon (Sendspin)
+After=dbus.service
+Requires=dbus.service
+Before=bluetooth.service sendspin-client.service
+
+[Service]
+Type=notify
+ExecStart=/usr/bin/pulseaudio --system --realtime --disallow-exit --no-cpu-limit --log-target=journal
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=5
+User=pulse
+Group=pulse
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+NoNewPrivileges=yes
+ProtectHome=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+RestrictNamespaces=yes
+RestrictRealtime=no
+
+[Install]
+WantedBy=multi-user.target

--- a/lxc/sendspin-client.service
+++ b/lxc/sendspin-client.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Sendspin Client (Music Assistant Player with Bluetooth)
+Documentation=https://github.com/loryanstrant/sendspin-client
+After=network-online.target dbus.service bluetooth.service pulseaudio-system.service avahi-daemon.service
+Wants=network-online.target
+Requires=pulseaudio-system.service dbus.service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+Environment=PYTHONUNBUFFERED=1
+ExecStartPre=/bin/sleep 3
+ExecStart=/usr/bin/python3 /opt/sendspin-client/sendspin_client.py
+WorkingDirectory=/opt/sendspin-client
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=sendspin-client
+
+[Install]
+WantedBy=multi-user.target

--- a/lxc/sendspin-client.service
+++ b/lxc/sendspin-client.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Sendspin Client (Music Assistant Player with Bluetooth)
 Documentation=https://github.com/loryanstrant/sendspin-client
-After=network-online.target dbus.service bluetooth.service pulseaudio-system.service avahi-daemon.service
+After=network-online.target dbus.service pulseaudio-system.service avahi-daemon.service
 Wants=network-online.target
 Requires=pulseaudio-system.service dbus.service
 
@@ -11,6 +11,8 @@ EnvironmentFile=/etc/environment
 Environment=PYTHONUNBUFFERED=1
 Environment=HOME=/root
 Environment=PULSE_SERVER=unix:/var/run/pulse/native
+# Use the host's D-Bus socket (bind-mounted at /bt-dbus) for Bluetooth control
+Environment=DBUS_SYSTEM_BUS_ADDRESS=unix:path=/bt-dbus/system_bus_socket
 Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ExecStartPre=/bin/sleep 3
 ExecStart=/usr/bin/python3 /opt/sendspin-client/sendspin_client.py

--- a/lxc/sendspin-client.service
+++ b/lxc/sendspin-client.service
@@ -14,11 +14,13 @@ Environment=PULSE_SERVER=unix:/var/run/pulse/native
 # Use the host's D-Bus socket (bind-mounted at /bt-dbus) for Bluetooth control
 Environment=DBUS_SYSTEM_BUS_ADDRESS=unix:path=/bt-dbus/system_bus_socket
 Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-ExecStartPre=/bin/sleep 3
+ExecStartPre=/bin/bash -c 'i=0; while [ $i -lt 30 ]; do [ -S /var/run/pulse/native ] && [ -e /bt-dbus/system_bus_socket ] && exit 0; sleep 1; i=$((i+1)); done; echo "Timeout waiting for PulseAudio/D-Bus sockets" >&2; exit 1'
 ExecStart=/usr/bin/python3 /opt/sendspin-client/sendspin_client.py
 WorkingDirectory=/opt/sendspin-client
 Restart=on-failure
 RestartSec=10
+NoNewPrivileges=yes
+PrivateTmp=yes
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=sendspin-client

--- a/lxc/sendspin-client.service
+++ b/lxc/sendspin-client.service
@@ -9,6 +9,9 @@ Requires=pulseaudio-system.service dbus.service
 Type=simple
 EnvironmentFile=/etc/environment
 Environment=PYTHONUNBUFFERED=1
+Environment=HOME=/root
+Environment=PULSE_SERVER=unix:/var/run/pulse/native
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ExecStartPre=/bin/sleep 3
 ExecStart=/usr/bin/python3 /opt/sendspin-client/sendspin_client.py
 WorkingDirectory=/opt/sendspin-client


### PR DESCRIPTION
## Summary

Adds a complete LXC-based deployment path for Proxmox VE users as an alternative to Docker.

### New files

- `lxc/proxmox-create.sh` — interactive script run on the Proxmox host; creates a privileged Ubuntu 24.04 LXC container with cgroup Bluetooth device rules, runs `install.sh` inside the container, then adds the D-Bus bind-mount and restarts
- `lxc/install.sh` — idempotent installer run inside the container; installs packages, downloads app from GitHub, configures PulseAudio system-mode, D-Bus policy, systemd units, and starts all services
- `lxc/pulse-system.pa` — PulseAudio `system.pa` with Bluetooth modules, anonymous-auth unix socket, and fallback null sink
- `lxc/pulseaudio-system.service` — systemd unit for PulseAudio system daemon (runs as `pulse` user)
- `lxc/sendspin-client.service` — systemd unit for the Python application
- `lxc/README.md` — full LXC deployment documentation

### Updated files

- `README.md` — LXC deployment section updated with correct architecture description and pointer to `lxc/README.md`

### Key architectural decisions

**AF_BLUETOOTH is not available in LXC network namespaces.** The container cannot run its own `bluetoothd`. Instead:

- `bluetoothd` runs on the Proxmox host
- The host's D-Bus socket (`/run/dbus`) is bind-mounted into the container at `/bt-dbus`
- PulseAudio and the `btctl` wrapper both use `DBUS_SYSTEM_BUS_ADDRESS=unix:path=/bt-dbus/system_bus_socket` to reach the host's bluetoothd
- The local `bluetooth.service` inside the container is explicitly disabled

**`btctl`** is a thin wrapper around `bluetoothctl` that sets the correct D-Bus address — users pair speakers from inside the container exactly as they would on a normal system.

### Security improvements (addressed in review)

- `pulseaudio-system.service` runs as dedicated `pulse` user (`User=pulse`, `Group=pulse`)
- `NoNewPrivileges=yes` set on both service units; `ProtectHome=no` removed
- `PrivateTmp=yes` added to `sendspin-client.service`
- `bluetooth` and `bluez` packages removed from container apt install (only `bluez-tools` needed for `btctl`)
- `ExecStartPre=/bin/sleep 3` replaced with socket-polling that waits for `/var/run/pulse/native` and `/bt-dbus/system_bus_socket`
- `pveam download` now has a post-wait error check
- Fixed `sleep` calls in `proxmox-create.sh` replaced with `systemctl is-system-running --wait` + container-stop polling
- Warning comment added for broad `c 189:* rwm` USB cgroup rule

## Testing

Tested on Proxmox VE 8.4.16:
- Container: Ubuntu 24.04, 512 MB RAM, 4 GB disk
- Music Assistant connection: verified (`Connected to server 'Music Assistant' version 1`)
- Bluetooth: Sony WH-1000XM4 paired and A2DP sink active (`bluez_sink.80_99_E7_C2_0B_D3.a2dp_sink`)
- Web UI: `http://<container-ip>:8080` responding
- `install.sh` idempotency: re-run with no errors

## Test Plan
- [ ] Run `proxmox-create.sh` on a PVE host
- [ ] Verify web UI accessible at container IP:8080
- [ ] Verify Music Assistant discovers the player
- [ ] Pair a Bluetooth speaker via `btctl` inside the container
- [ ] Set `BLUETOOTH_MAC` in web UI, restart service, verify audio routes to BT sink