### PR TITLE
feat(web): clean up BT stack on device deletion or adapter change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ config.json
 .pytest_cache/
 .coverage
 htmlcov/
+
+# Worktrees
+.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,79 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.2.1] - 2026-02-28
+
+### Fixed
+- Shell injection risk in `_run_bluetoothctl` — replaced string-formatted bash command with stdin pipe
+- XSS vulnerability in web UI — HTML attribute positions now use `escHtmlAttr()` instead of `escHtml()`
+- `monitor_output` task not cancelled when sendspin process restarts, causing duplicate log readers
+- Signal handler used `asyncio.create_task` which could leave orphaned tasks on shutdown
+- Per-player audio format cache was a module-level global, causing wrong format shown for second device in multi-device setups
+- Removed dead code: `ClientHolder` class and `get_client_instance()` function
+
+## [1.2.0] - 2026-02-28
+
+### Added
+- **Multi-device support** — bridge multiple Bluetooth speakers simultaneously, each appearing as a separate player in Music Assistant; configure via `BLUETOOTH_DEVICES` array in `config.json`
+- **Home Assistant addon** (`ha-addon/`) — native HA addon with Ingress support; web UI appears directly in the HA sidebar
+- **Proxmox LXC deployment** (`lxc/`) — fully headless deployment without Docker:
+  - `lxc/proxmox-create.sh` — one-command LXC container creation on Proxmox host with Bluetooth D-Bus passthrough and system-mode PulseAudio
+  - `lxc/install.sh` — in-container installer for dependencies and systemd units
+  - `btctl` wrapper for Bluetooth control via host D-Bus socket
+- **Multi-adapter support** — `adapter` field in device config pins a speaker to a specific Bluetooth controller (`hci0`, `hci1`, …)
+- **Per-device latency compensation** — `static_delay_ms` field compensates for A2DP + PulseAudio buffer latency (default `-500ms`)
+- **Per-device listen port/host** — `listen_port` and `listen_host` fields control per-player Sendspin daemon binding
+- **Volume persistence per device** — volume saved per MAC address under `LAST_VOLUMES` in `config.json`, restored on reconnect
+- **Group volume/mute controls** — control all players simultaneously from the web UI
+- **Reconnect and Re-pair buttons** — per-device controls in the status dashboard
+- **Bluetooth scan filtering** — scan results filtered to audio-capable devices only (by BT device class / A2DP UUID)
+- **BT adapter management panel** — auto-detect adapters with manual override support
+- **`/api/diagnostics` endpoint** — structured health info: adapters, sinks, D-Bus availability, per-device status
+- **Audio format display** — codec, sample rate, and bit depth shown in device status cards (e.g. `flac 48000Hz/24-bit/2ch`)
+- **Sync status tracking** — re-anchor count and last sync error shown in device cards
+- **Timezone autocomplete** — IANA timezone list in configuration UI
+- **Per-player WebSocket URL** — displayed in device cards for debugging
+
+### Changed
+- `BLUETOOTH_MAC` env var superseded by `BLUETOOTH_DEVICES` array (backward compatible — single MAC still supported)
+- `SENDSPIN_NAME` used as player name prefix
+- Device info reported to Music Assistant set to `Sendspin / Bluetooth Bridge`
+- `PULSE_SINK` set per-process for isolated audio routing per device
+- Audio route configured without changing system default sink (per-process via `PULSE_SINK`)
+- Removed Player Name Prefix field from configuration UI
+
+### Fixed
+- Bluetooth disconnect detection reliability improvements
+- `bluetooth_sink_name` not set when sendspin process restarts after unexpected death
+- Volume/mute controls disabled when audio sink not yet configured
+- Bluetooth `AF_BLUETOOTH` kernel namespace limitation in LXC resolved via host D-Bus bridge
+- Playing status detection updated for actual sendspin log output format
+- BT scan: stdin kept open so bluetoothctl has time to discover devices
+- Volume sync: parse `Server set player volume` log format from Music Assistant
+- `LAST_VOLUMES` preserved when saving configuration via web UI
+
+## [1.1.0] - 2026-01-27 (upstream: loryanstrant/Sendspin-client)
+
+### Fixed
+- Bluetooth connection status monitoring reliability
+- Bluetooth disconnect detection with real-time status polling
+
+## [1.0.0] - 2026-01-01 (upstream: loryanstrant/Sendspin-client)
+
+### Added
+- Initial release: Dockerized Sendspin client with Bluetooth speaker management
+- Flask web UI served by Waitress on port 8080
+- Auto-reconnect to Bluetooth device every 10 seconds
+- PipeWire and PulseAudio sink detection and routing
+- Volume sync from Music Assistant to Bluetooth speaker via `pactl`
+- mDNS auto-discovery for Music Assistant server (`SENDSPIN_SERVER=auto`)
+- Config persistence via `/config/config.json`
+
+[1.2.1]: https://github.com/trudenboy/sendspin-bt-bridge/compare/v1.2.0...v1.2.1
+[1.2.0]: https://github.com/trudenboy/sendspin-bt-bridge/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/loryanstrant/Sendspin-client/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/loryanstrant/Sendspin-client/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Signal handler used `asyncio.create_task` which could leave orphaned tasks on shutdown
 - Per-player audio format cache was a module-level global, causing wrong format shown for second device in multi-device setups
 - Removed dead code: `ClientHolder` class and `get_client_instance()` function
+- LXC: `module-bluetooth-policy auto_switch=never` added to `pulse-system.pa` — fixes A2DP connection failure for devices that advertise HFP/HSP profiles (e.g. ENEBY Portable); SCO sockets required by HFP are unavailable in LXC kernel namespaces, causing `br-connection-unknown` disconnect before PulseAudio could create the A2DP sink
 
 ## [1.2.0] - 2026-02-28
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+A Dockerized Python client that bridges Music Assistant's Sendspin protocol to Bluetooth speakers, with a Flask web UI for configuration and status monitoring. Designed for headless systems (Raspberry Pi, Home Assistant).
+
+## Development Commands
+
+```bash
+# Build and run locally
+docker compose up --build
+
+# Run without Docker (requires system Bluetooth/audio packages)
+pip install -r requirements.txt
+python sendspin_client.py
+
+# View container logs
+docker logs -f sendspin-client
+
+# Bluetooth troubleshooting inside container
+docker exec -it sendspin-client bluetoothctl
+```
+
+There is no test suite. Manual testing is via `docker logs` and the web UI at `http://localhost:8080`.
+
+CI/CD builds multi-platform Docker images (`linux/amd64`, `linux/arm64`) to `ghcr.io/loryanstrant/sendspin-client` on push to `main`.
+
+## Architecture
+
+Two main Python files:
+
+**`sendspin_client.py`** - Core application:
+- `BluetoothManager` - Manages Bluetooth pairing/connection via `bluetoothctl` subprocess. Auto-reconnects every 10 seconds. Handles both PipeWire and PulseAudio sink routing.
+- `SendspinClient` - Wraps the `sendspin` CLI (run as subprocess with `--headless`). Parses CLI output to track playback state and syncs volume to the Bluetooth sink via `pactl`.
+- `main()` - Loads config, instantiates both classes, starts web server in a daemon thread, then runs the async event loop.
+
+**`web_interface.py`** - Flask app served by Waitress on port 8080:
+- Embeds all HTML/CSS/JS inline (no template files or static assets)
+- Polls `/api/status` every 2 seconds to update the dashboard
+- `/api/config` GET/POST reads/writes `/config/config.json`
+- `/api/volume` invokes `pactl` to set speaker volume
+
+**Config persistence:** `/config/config.json` (mounted Docker volume at `/etc/docker/Sendspin`). Changes via the web UI require a container restart to take effect.
+
+## Key Environment Variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `SENDSPIN_NAME` | `Docker-{hostname}` | Player display name in Music Assistant |
+| `SENDSPIN_SERVER` | `auto` | Server hostname/IP; `auto` uses mDNS discovery |
+| `SENDSPIN_PORT` | `9000` | WebSocket port (`ws://{server}:{port}/sendspin`) |
+| `BLUETOOTH_MAC` | `` | Target speaker MAC address (Bluetooth disabled if empty) |
+| `WEB_PORT` | `8080` | Web interface port |
+| `TZ` | `Australia/Melbourne` | Container timezone |
+
+## Container Requirements
+
+- Network mode: `host` (required for mDNS auto-discovery)
+- Privileged mode + capabilities `NET_ADMIN`, `NET_RAW`, `SYS_ADMIN` (required for Bluetooth)
+- Volume mounts: D-Bus socket, PulseAudio/PipeWire sockets, config directory
+- `entrypoint.sh` handles D-Bus setup, audio system detection, and volume restoration before starting the Python app
+
+## Audio Sink Detection
+
+`BluetoothManager.configure_bluetooth_audio()` tries multiple `pactl` sink naming patterns for the connected device:
+- `bluez_output.{MAC}.1` (PipeWire)
+- `bluez_output.{MAC}.a2dp-sink`
+- `bluez_sink.{MAC}.a2dp_sink` (legacy PulseAudio)
+- `bluez_sink.{MAC}`

--- a/README.md
+++ b/README.md
@@ -406,10 +406,13 @@ python sendspin_client.py
 - Built for [Music Assistant](https://www.music-assistant.io/)
 - Uses the `sendspin` CLI from the MA project
 - Inspired by [sendspin-go](https://github.com/Sendspin/sendspin-go)
+- Upstream repository: [loryanstrant/Sendspin-client](https://github.com/loryanstrant/Sendspin-client)
+- Born from the MA community discussion: [Sendspin Bluetooth Bridge #4677](https://github.com/orgs/music-assistant/discussions/4677)
 
 ## Support
 
 - **Issues**: [GitHub Issues](https://github.com/trudenboy/sendspin-bt-bridge/issues)
+- **Original discussion**: [music-assistant/discussions #4677](https://github.com/orgs/music-assistant/discussions/4677)
 - **Music Assistant community**: [Discord](https://discord.gg/kaVm8hGpne)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,200 +1,98 @@
-# Sendspin Docker Client
+# Sendspin Bluetooth Bridge
 
-A Docker-based Sendspin client with Bluetooth speaker support and web-based configuration interface. Perfect for running on headless systems like Raspberry Pi or Home Assistant installations.
+A Bluetooth bridge for [Music Assistant](https://www.music-assistant.io/) — connects your Bluetooth speakers to the MA Sendspin protocol. Runs as a Docker container, a Home Assistant addon, or a native LXC container on Proxmox VE. Designed for headless systems.
 
 [Why did I build this?](why-did-I-build-this.md)
 
 ## Features
 
-- ✅ **Sendspin Protocol**: Full support for Music Assistant's Sendspin protocol
-- 🔊 **Bluetooth Audio**: Automatic connection and reconnection to Bluetooth speakers
-- 🌐 **Web Interface**: Easy configuration and real-time status monitoring
-- 🐳 **Docker Ready**: Fully containerized with minimal host dependencies
-- 🔄 **Auto-reconnect**: Automatically handles Bluetooth speaker disconnections
-- 📊 **Status Reporting**: Reports speaker state and container info to Music Assistant
-- 🕐 **Timezone Support**: Configurable timezone for accurate scheduling
+- **Sendspin Protocol**: Full support for Music Assistant's native Sendspin streaming protocol
+- **Multi-device**: Bridge multiple Bluetooth speakers simultaneously, each appearing as its own MA player
+- **Auto-reconnect**: Monitors speaker connections every 10 s and reconnects automatically
+- **Web Interface**: Real-time status dashboard and configuration UI on port 8080
+- **Three deployment options**: Home Assistant addon, Docker Compose, or Proxmox LXC
+- **PipeWire & PulseAudio**: Auto-detects the host audio system
+- **Player metadata**: Reports real device manufacturer and model to Music Assistant
+- **Group controls**: Volume and mute controls across multiple players from the web UI
 
 <img width="1233" height="657" alt="image" src="https://github.com/user-attachments/assets/d5f3f733-b073-4a08-b23a-feb3efc4daf7" />
 <br><br>
 
 <img width="1187" height="257" alt="image" src="https://github.com/user-attachments/assets/72080af9-819a-4f63-9f1f-81e87a469d03" />
 
+---
 
+## Deployment Options
 
-## Proxmox VE (LXC) Deployment
-
-Run Sendspin Client as a **native LXC container** on Proxmox VE — no Docker required. The LXC container runs its own `bluetoothd`, `pulseaudio`, and `avahi-daemon`, with USB Bluetooth hardware passed through via cgroup rules.
-
-### Docker vs LXC comparison
-
-| Feature | Docker | LXC (Proxmox) |
-|---------|--------|---------------|
-| Deployment target | Any Docker host | Proxmox VE 7/8 |
-| Bluetooth | Uses host's bluetoothd via D-Bus socket | Own bluetoothd inside container |
-| Audio | Uses host's PulseAudio/PipeWire socket | Own pulseaudio --system inside container |
-| mDNS discovery | Uses host's avahi-daemon | Own avahi-daemon inside container |
-| Config changes | Container restart | `systemctl restart sendspin-client` |
-| USB BT adapter | Host passthrough | cgroup passthrough to LXC |
-
-### One-line install (on Proxmox host as root)
-
-```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/loryanstrant/sendspin-client/main/lxc/proxmox-create.sh)
-```
-
-The script will interactively prompt for container ID, hostname, RAM, disk, network, and USB Bluetooth passthrough options.
-
-### Prerequisites
-
-- Proxmox VE 7 or 8
-- USB Bluetooth adapter (or onboard Bluetooth on the Proxmox host)
-- Debian 12 LXC template available in Proxmox (the script downloads it automatically)
-
-### Manual install steps (Proxmox UI)
-
-If you prefer to create the container via the Proxmox web UI:
-
-1. Create a new **privileged** LXC container (Debian 12, 512 MB RAM, 4 GB disk)
-2. Start the container and open a shell (`pct enter <CTID>`)
-3. Run the installer:
-   ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/loryanstrant/sendspin-client/main/lxc/install.sh)
-   ```
-4. Append the following to `/etc/pve/lxc/<CTID>.conf` on the **Proxmox host**:
-   ```
-   lxc.cgroup2.devices.allow: c 166:* rwm
-   lxc.cgroup2.devices.allow: c 13:* rwm
-   lxc.mount.entry: /dev/bus/usb dev/bus/usb none bind,optional,create=dir 0 0
-   # If using a USB Bluetooth adapter:
-   lxc.cgroup2.devices.allow: c 189:* rwm
-   ```
-5. Restart the container: `pct restart <CTID>`
-
-### Bluetooth speaker pairing (inside the container)
-
-```bash
-# Enter the container
-pct enter <CTID>
-
-# Start interactive Bluetooth manager
-bluetoothctl
-
-# Inside bluetoothctl:
-power on
-scan on
-# Wait for your speaker to appear, then:
-pair XX:XX:XX:XX:XX:XX
-trust XX:XX:XX:XX:XX:XX
-connect XX:XX:XX:XX:XX:XX
-exit
-```
-
-Then set `BLUETOOTH_MAC` in `/config/config.json` and restart the service.
-
-### Key monitoring commands
-
-```bash
-# View application logs
-pct exec <CTID> -- journalctl -u sendspin-client -f
-
-# Check all service statuses
-pct exec <CTID> -- systemctl status sendspin-client pulseaudio-system bluetooth avahi-daemon --no-pager
-
-# List audio sinks (confirm Bluetooth sink is present)
-pct exec <CTID> -- pactl list sinks short
-
-# Check Bluetooth adapter
-pct exec <CTID> -- bluetoothctl show
-
-# Verify PulseAudio socket
-pct exec <CTID> -- ls -la /var/run/pulse/native
-```
-
-### Manual USB Bluetooth passthrough
-
-To pass through a specific USB Bluetooth adapter, find its device numbers on the Proxmox host:
-
-```bash
-lsusb | grep -i bluetooth
-# Example output: Bus 001 Device 003: ID 0a12:0001 Cambridge Silicon Radio, Ltd Bluetooth Dongle
-
-# Map Bus 001 Device 003 → /dev/bus/usb/001/003
-```
-
-Then add to `/etc/pve/lxc/<CTID>.conf`:
-```
-lxc.cgroup2.devices.allow: c 189:* rwm
-lxc.mount.entry: /dev/bus/usb dev/bus/usb none bind,optional,create=dir 0 0
-```
-
-> **Note:** Configuration changes in `/config/config.json` take effect after:
-> ```bash
-> pct exec <CTID> -- systemctl restart sendspin-client
-> ```
-> There is no need to restart the container.
+| | Home Assistant Addon | Docker Compose | Proxmox LXC |
+|---|---|---|---|
+| Install method | HA Addon Store (one-click) | `docker compose up` | One-line script |
+| Bluetooth | Host bluetoothd via D-Bus | Host bluetoothd via D-Bus | Own bluetoothd inside LXC |
+| Audio | HA Supervisor bridge | Host PulseAudio/PipeWire | Own PulseAudio inside LXC |
+| Config UI | HA panel + web UI | Web UI at :8080 | Web UI at :8080 |
+| Config changes | Addon restart | Container restart | `systemctl restart` |
 
 ---
 
-## Quick Start
+## Option A — Home Assistant Addon
+
+### Install
+
+1. In Home Assistant go to **Settings → Add-ons → Add-on store → ⋮ → Repositories**
+2. Add: `https://github.com/trudenboy/sendspin-bt-bridge`
+3. Find **Sendspin Bluetooth Bridge** in the store and click **Install**
+
+### Configure
+
+In the addon **Configuration** tab:
+
+```yaml
+sendspin_server: auto          # or your MA hostname/IP
+sendspin_port: 9000
+bluetooth_devices:
+  - mac: "AA:BB:CC:DD:EE:FF"
+    player_name: "Living Room Speaker"
+  - mac: "11:22:33:44:55:66"
+    player_name: "Kitchen Speaker"
+    adapter: hci1              # optional — only needed for multi-adapter setups
+```
+
+The addon exposes the web UI via **HA Ingress** (no port forwarding needed) and appears in the HA sidebar.
+
+### Requirements
+
+- Home Assistant OS or Supervised
+- Bluetooth adapter accessible to the host
+- Music Assistant server running on your network (any host)
+
+### Audio routing (HA OS)
+
+The addon requests `audio: true` in its manifest so HA Supervisor injects `PULSE_SERVER` automatically. No manual socket configuration is needed.
+
+---
+
+## Option B — Docker Compose
 
 ### Prerequisites
 
-- Docker and Docker Compose installed
-- Bluetooth adapter on the host system (if using Bluetooth speakers)
+- Docker and Docker Compose
+- Bluetooth speakers **paired** with the host before starting the container
 - Music Assistant server running on your network
 
-**Important**: If using Bluetooth speakers, they must be paired with the host system before starting the container. The container will use the host's Bluetooth adapter via D-Bus.
+### Pair speakers on the host first
 
-### Bluetooth Setup on Host
-
-Ensure Bluetooth is enabled on the host:
-
-```bash
-# Check if Bluetooth is available
-hciconfig
-
-# Enable Bluetooth if needed
-sudo systemctl enable bluetooth
-sudo systemctl start bluetooth
-
-# Ensure your user (or the container) can access Bluetooth
-sudo usermod -a -G bluetooth $USER
-```
-
-To pair a Bluetooth speaker on the host:
 ```bash
 bluetoothctl
 scan on
-# Wait for your device to appear
-pair XX:XX:XX:XX:XX:XX
+pair  XX:XX:XX:XX:XX:XX
 trust XX:XX:XX:XX:XX:XX
 connect XX:XX:XX:XX:XX:XX
 exit
 ```
 
-
-### Permissions
-
-The container requires:
-- `privileged: true` for Bluetooth access
-- `network_mode: host` for mDNS discovery
-- Access to `/var/run/dbus` for Bluetooth communication
-- Access to `/dev/bus/usb` for USB Bluetooth adapters
-
-
-
-### Installation
-
-1. Create the configuration directory:
-```bash
-sudo mkdir -p /etc/docker/Sendspin
-```
-
-2. Customise Docker compose & deploy using pre-built image (Recommended)
+### docker-compose.yml
 
 ```yaml
-version: '3.8'
-
 services:
   sendspin-client:
     image: ghcr.io/loryanstrant/sendspin-client:latest
@@ -202,217 +100,348 @@ services:
     restart: unless-stopped
     network_mode: host
     privileged: true
-    
+
     volumes:
       - /var/run/dbus:/var/run/dbus
+      - /run/user/1000/pulse:/run/user/1000/pulse   # PulseAudio
       - /etc/docker/Sendspin:/config
-    
+
     environment:
-      - SENDSPIN_NAME=Living Room
-      - SENDSPIN_SERVER=ma.local
-      - SENDSPIN_PORT=9000
-      - BLUETOOTH_MAC=04:57:91:D8:EC:9D
+      - SENDSPIN_SERVER=auto
       - TZ=Australia/Melbourne
       - WEB_PORT=8080
-    
+
     devices:
       - /dev/bus/usb:/dev/bus/usb
-    
+
     cap_add:
       - NET_ADMIN
       - NET_RAW
       - SYS_ADMIN
 ```
 
+Create config directory and start:
 
-3. Access the web interface:
+```bash
+sudo mkdir -p /etc/docker/Sendspin
+docker compose up -d
 ```
-http://your-host-ip:8080
+
+Access the web UI at `http://your-host-ip:8080` to add Bluetooth devices and set the MA server.
+
+---
+
+## Option C — Proxmox VE (LXC)
+
+Run as a **native LXC container** — no Docker required. The container runs its own `bluetoothd`, `pulseaudio`, and `avahi-daemon` with USB Bluetooth hardware passed through via cgroup rules.
+
+### One-line install (on the Proxmox host as root)
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/loryanstrant/sendspin-client/main/lxc/proxmox-create.sh)
 ```
+
+The script interactively prompts for container ID, hostname, RAM, disk, network, and USB Bluetooth passthrough.
+
+### Manual steps (Proxmox UI)
+
+1. Create a new **privileged** LXC container (Debian 12, 512 MB RAM, 4 GB disk)
+2. Start the container and open a shell (`pct enter <CTID>`)
+3. Run the installer:
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/loryanstrant/sendspin-client/main/lxc/install.sh)
+   ```
+4. Append to `/etc/pve/lxc/<CTID>.conf` on the **Proxmox host**:
+   ```
+   lxc.cgroup2.devices.allow: c 166:* rwm
+   lxc.cgroup2.devices.allow: c 13:* rwm
+   lxc.mount.entry: /dev/bus/usb dev/bus/usb none bind,optional,create=dir 0 0
+   lxc.cgroup2.devices.allow: c 189:* rwm
+   ```
+5. Restart the container: `pct restart <CTID>`
+
+### Bluetooth pairing inside the LXC
+
+```bash
+pct enter <CTID>
+bluetoothctl
+power on
+scan on
+pair  XX:XX:XX:XX:XX:XX
+trust XX:XX:XX:XX:XX:XX
+connect XX:XX:XX:XX:XX:XX
+exit
+```
+
+Then add the device in `/config/config.json` and restart the service:
+
+```bash
+pct exec <CTID> -- systemctl restart sendspin-client
+```
+
+### Key monitoring commands
+
+```bash
+pct exec <CTID> -- journalctl -u sendspin-client -f
+pct exec <CTID> -- systemctl status sendspin-client pulseaudio-system bluetooth avahi-daemon --no-pager
+pct exec <CTID> -- pactl list sinks short
+pct exec <CTID> -- bluetoothctl show
+```
+
+---
 
 ## Configuration
 
-The Sendspin client can also be configured through the web interface at `http://your-host:8080`.
+### Multi-device config (`/config/config.json`)
 
-### Configuration Options
+The recommended way to configure multiple speakers:
 
-- **Player Name**: The name that appears in Music Assistant (configured via web UI)
-- **Server**: Use `auto` for automatic mDNS discovery, or specify a hostname/IP
-- **Bluetooth MAC**: MAC address of your Bluetooth speaker (optional)
-- **Timezone**: Your local timezone
+```json
+{
+  "SENDSPIN_NAME": "Sendspin-Bridge",
+  "SENDSPIN_SERVER": "auto",
+  "SENDSPIN_PORT": "9000",
+  "BLUETOOTH_DEVICES": [
+    {
+      "mac": "80:99:E7:C2:0B:D3",
+      "player_name": "Living Room",
+      "adapter": "hci0"
+    },
+    {
+      "mac": "FC:58:FA:EB:08:6C",
+      "player_name": "Kitchen",
+      "adapter": "hci1"
+    }
+  ],
+  "TZ": "Australia/Melbourne"
+}
+```
 
-**Note**: Configuration changes require a container restart to take effect.
+Each device in `BLUETOOTH_DEVICES` spawns an independent Sendspin player and Bluetooth manager. Both appear as separate players in Music Assistant.
+
+The `adapter` field is optional — omit it if you only have one Bluetooth adapter. Set it to `hci0`, `hci1`, etc. when you have multiple adapters and want to pin a speaker to a specific one.
+
+### Legacy single-device config (still supported)
+
+```json
+{
+  "SENDSPIN_SERVER": "auto",
+  "BLUETOOTH_MAC": "AA:BB:CC:DD:EE:FF"
+}
+```
+
 ### Environment Variables
 
-| Variable | Description | Default | Required |
-|----------|-------------|---------|----------|
-| `SENDSPIN_NAME` | Player name in Music Assistant | `Docker-{hostname}` | No |
-| `SENDSPIN_SERVER` | Music Assistant server hostname/IP | `ma.strant.casa` | Yes |
-| `SENDSPIN_PORT` | Sendspin server port | `9000` | Yes |
-| `BLUETOOTH_MAC` | Bluetooth speaker MAC address | - | No* |
-| `TZ` | Timezone (e.g., `Australia/Melbourne`) | `Australia/Melbourne` | No |
-| `WEB_PORT` | Web interface port | `8080` | No |
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SENDSPIN_NAME` | `Docker-{hostname}` | Base player name shown in Music Assistant |
+| `SENDSPIN_SERVER` | `auto` | MA server hostname/IP; `auto` uses mDNS discovery |
+| `SENDSPIN_PORT` | `9000` | MA Sendspin WebSocket port |
+| `BLUETOOTH_MAC` | `` | Single speaker MAC (legacy; use `BLUETOOTH_DEVICES` in config.json instead) |
+| `TZ` | `Australia/Melbourne` | Container timezone |
+| `WEB_PORT` | `8080` | Web interface port |
 
-*Leave empty to disable Bluetooth functionality
-
+Environment variables are overridden by values in `/config/config.json` if the file exists.
 
 ### Web Interface
 
-The web interface provides:
+The web UI at `http://your-host:8080` (or via HA Ingress) provides:
 
-- **Real-time Status**: View connection status, playback state, and system info
-- **Configuration**: Change settings without editing files
-- **Monitoring**: See when the speaker connects/disconnects
-- **System Info**: View IP address, hostname, and uptime
+- **Per-device cards**: Connection status, playback state, volume slider, mute toggle
+- **Reconnect / Re-pair buttons**: Trigger manual reconnect or full re-pair without restarting
+- **Group controls**: Set volume or mute across all devices at once
+- **Configuration page**: Edit server address, add/remove Bluetooth devices
+- **System info**: IP address, hostname, uptime, audio sink status
 
-
-
-
-## Troubleshooting
-
-### Bluetooth Speaker Won't Connect
-
-1. **Check Bluetooth availability**:
-```bash
-docker exec -it sendspin-client bluetoothctl
-power on
-scan on
-```
-
-2. **Pair manually if needed**:
-```bash
-docker exec -it sendspin-client bluetoothctl
-pair XX:XX:XX:XX:XX:XX
-trust XX:XX:XX:XX:XX:XX
-connect XX:XX:XX:XX:XX:XX
-```
-
-3. **Check container logs**:
-```bash
-docker logs sendspin-client
-```
-
-### Can't Connect to Music Assistant
-
-1. Verify the server address and port in your configuration
-2. Ensure the container is on the same network (using `network_mode: host`)
-3. Check Music Assistant logs for connection attempts
-4. Verify firewall rules aren't blocking port 9000
-
-### Web Interface Not Accessible
-
-1. Check if the port is correct: `docker ps`
-2. Ensure no other service is using port 8080
-3. Try accessing via the host's IP: `http://192.168.1.x:8080`
-
-### Container Restarts Frequently
-
-1. Check logs: `docker logs sendspin-client`
-2. Verify Bluetooth adapter is working: `hciconfig`
-3. Check D-Bus is running: `ps aux | grep dbus`
+---
 
 ## Architecture
 
 ```
 ┌─────────────────────────────────────┐
 │     Music Assistant Server          │
-│         (Sendspin Server)           │
+│  (built-in Sendspin provider)       │
 └──────────────┬──────────────────────┘
-               │ WebSocket (port 9000)
+               │ WebSocket ws://<ma>:9000/sendspin
                │
 ┌──────────────▼──────────────────────┐
-│     Sendspin Docker Client          │
-│  ┌──────────────────────────────┐   │
-│  │   Python Sendspin Client     │   │
-│  │   - aiosendspin library      │   │
-│  │   - Audio streaming          │   │
-│  │   - Status reporting         │   │
-│  └──────────────────────────────┘   │
-│  ┌──────────────────────────────┐   │
-│  │   Bluetooth Manager          │   │
-│  │   - bluetoothctl interface   │   │
-│  │   - Auto-reconnect logic     │   │
-│  │   - Connection monitoring    │   │
-│  └──────────────────────────────┘   │
-│  ┌──────────────────────────────┐   │
-│  │   Web Interface (Flask)      │   │
-│  │   - Configuration UI         │   │
-│  │   - Status dashboard         │   │
-│  │   - Real-time monitoring     │   │
-│  └──────────────────────────────┘   │
-└──────────────┬──────────────────────┘
-               │ Bluetooth
-               │
-┌──────────────▼──────────────────────┐
-│      Bluetooth Speaker              │
-└─────────────────────────────────────┘
+│     Sendspin Bluetooth Bridge       │
+│                                     │
+│  ┌─────────────────────────────┐    │
+│  │  SendspinClient (per device)│    │
+│  │  · sendspin CLI subprocess  │    │
+│  │  · playback state tracking  │    │
+│  │  · volume sync via pactl    │    │
+│  └─────────────────────────────┘    │
+│  ┌─────────────────────────────┐    │
+│  │  BluetoothManager           │    │
+│  │  · bluetoothctl interface   │    │
+│  │  · auto-reconnect every 10s │    │
+│  │  · PipeWire/PulseAudio sink │    │
+│  └─────────────────────────────┘    │
+│  ┌─────────────────────────────┐    │
+│  │  Web Interface (Flask/8080) │    │
+│  │  · status dashboard         │    │
+│  │  · config editor            │    │
+│  │  · group controls           │    │
+│  └─────────────────────────────┘    │
+└──────────┬──────────────────────────┘
+           │ Bluetooth A2DP
+    ┌──────┴──────┐
+    │  Speaker 1  │  Speaker 2  │  ...
+    └─────────────┘
 ```
 
-## Development
+---
 
-### Building from Source
+## Troubleshooting
 
-```bash
-git clone https://github.com/loryanstrant/Sendspin-client.git
-cd Sendspin-client
-docker build -t sendspin-client .
-```
-
-### Running Tests
+### Bluetooth speaker won't connect
 
 ```bash
-# Test Bluetooth connectivity
+# Docker
 docker exec -it sendspin-client bluetoothctl info XX:XX:XX:XX:XX:XX
 
-# Test Sendspin connection
+# Pair manually
+docker exec -it sendspin-client bluetoothctl
+pair XX:XX:XX:XX:XX:XX
+trust XX:XX:XX:XX:XX:XX
+connect XX:XX:XX:XX:XX:XX
+
+# Check logs
 docker logs -f sendspin-client
 ```
 
-### Modifying the Code
+### Can't connect to Music Assistant
 
-The main components are:
+1. Verify `SENDSPIN_SERVER` is correct or use `auto`
+2. Ensure `network_mode: host` is set (required for mDNS)
+3. Check MA logs for incoming Sendspin connections
+4. Verify port 9000 is reachable from the host
 
-- `sendspin_client.py`: Core Sendspin client with Bluetooth management
-- `web_interface.py`: Flask web application for UI
-- `entrypoint.sh`: Container startup script
-- `Dockerfile`: Container build configuration
-- `docker-compose.yml`: Docker Compose orchestration
+### Audio routing issues (Docker)
+
+The container needs access to the host audio socket. Add to `docker-compose.yml`:
+
+```yaml
+volumes:
+  - /run/user/1000/pulse:/run/user/1000/pulse
+environment:
+  - PULSE_SERVER=unix:/run/user/1000/pulse/native
+```
+
+For PipeWire:
+```yaml
+volumes:
+  - /run/user/1000/pipewire-0:/run/user/1000/pipewire-0
+```
+
+### No audio sink after Bluetooth connects
+
+The app tries several naming patterns automatically:
+- `bluez_output.{MAC}.1` (PipeWire)
+- `bluez_output.{MAC}.a2dp-sink`
+- `bluez_sink.{MAC}.a2dp_sink` (PulseAudio)
+- `bluez_sink.{MAC}`
+
+List available sinks to confirm which is active:
+
+```bash
+docker exec -it sendspin-client pactl list short sinks
+```
+
+---
+
+## Development
+
+```bash
+# Clone
+git clone https://github.com/trudenboy/sendspin-bt-bridge.git
+cd sendspin-bt-bridge
+
+# Build and run locally
+docker compose up --build
+
+# View logs
+docker logs -f sendspin-client
+
+# Run without Docker (requires system BT/audio packages)
+pip install -r requirements.txt
+python sendspin_client.py
+```
+
+### Project structure
+
+| File | Purpose |
+|------|---------|
+| `sendspin_client.py` | Core app — `BluetoothManager`, `SendspinClient`, `main()` |
+| `web_interface.py` | Flask web UI served by Waitress |
+| `entrypoint.sh` | Container startup — D-Bus, audio socket detection, app launch |
+| `Dockerfile` | Container image |
+| `docker-compose.yml` | Docker Compose orchestration |
+| `ha-addon/config.yaml` | Home Assistant addon manifest |
+| `ha-addon/Dockerfile` | HA addon image (thin wrapper over main image) |
+| `ha-addon/run.sh` | HA entry point — translates options.json → config.json |
+| `ha-addon/translations/en.yaml` | HA UI labels |
+| `lxc/` | Proxmox LXC install scripts |
+
+---
 
 ## Contributing
 
-Contributions are welcome! Please:
-
 1. Fork the repository
-2. Create a feature branch
+2. Create a feature branch off `integration`
 3. Make your changes
-4. Submit a pull request
+4. Submit a pull request against `integration`
+
+---
 
 ## Development Approach
 <img width="256" height="256" alt="image" src="https://github.com/user-attachments/assets/3e6903cf-2bfa-4f10-bc25-8bf3de5e2f3a" />
 
-
-## License
-
-MIT License - see LICENSE file for details
+---
 
 ## Credits
 
 - Built for [Music Assistant](https://www.music-assistant.io/)
-- Uses [aiosendspin](https://github.com/Sendspin/aiosendspin) library
+- Uses the `sendspin` CLI from the MA project
 - Inspired by [sendspin-go](https://github.com/Sendspin/sendspin-go)
 
 ## Support
 
-- **Issues**: [GitHub Issues](https://github.com/loryanstrant/Sendspin-client/issues)
-- **Music Assistant**: [Discord](https://discord.gg/kaVm8hGpne)
+- **Issues**: [GitHub Issues](https://github.com/trudenboy/sendspin-bt-bridge/issues)
+- **Music Assistant community**: [Discord](https://discord.gg/kaVm8hGpne)
+
+## License
+
+MIT License — see [LICENSE](LICENSE) for details.
+
+---
 
 ## Changelog
 
-### v1.0.0 (2026-01-01)
+### v1.2.0
+
+- **Home Assistant addon** — install directly from HA Addon Store via custom repository
+- **Multi-adapter support** — pin each device to a specific Bluetooth adapter (`hci0`, `hci1`, …)
+- **Reconnect / Re-pair buttons** in the web UI per device card
+- **Group volume and mute controls** across all players
+- **Audio-only BT scan filter** — only audio-capable devices shown during scan
+- **Real device manufacturer** reported to Music Assistant player info
+- **HA audio socket detection** — `entrypoint.sh` checks `PULSE_SERVER`, `/run/audio/pulse.sock`, then standard paths
+- Code review fixes: reliability and dead code cleanup
+
+### v1.1.0
+
+- Multi-device support (`BLUETOOTH_DEVICES` array in config.json)
+- Each device appears as a separate player in Music Assistant
+- Web UI device cards with per-device status
+
+### v1.0.0
 
 - Initial release
 - Sendspin protocol support
-- Bluetooth speaker management
+- Single Bluetooth speaker management
 - Web-based configuration interface
 - Docker container with auto-reconnect
 - GHCR image publishing

--- a/README.md
+++ b/README.md
@@ -15,10 +15,9 @@ A Bluetooth bridge for [Music Assistant](https://www.music-assistant.io/) — co
 - **Player metadata**: Reports real device manufacturer and model to Music Assistant
 - **Group controls**: Volume and mute controls across multiple players from the web UI
 
-<img width="1233" height="657" alt="image" src="https://github.com/user-attachments/assets/d5f3f733-b073-4a08-b23a-feb3efc4daf7" />
+<img width="1228" height="2694" alt="192 168 10 180_8080_ (1)" src="https://github.com/user-attachments/assets/ff3d99bc-7f8a-459b-ba9a-9ba3c10bedd6" />
 <br><br>
-
-<img width="1187" height="257" alt="image" src="https://github.com/user-attachments/assets/72080af9-819a-4f63-9f1f-81e87a469d03" />
+<img width="1019" height="245" alt="Screenshot 2026-02-28 at 17 03 49" src="https://github.com/user-attachments/assets/7654570b-bada-4cca-a195-4ced53c8d398" />
 
 ---
 
@@ -393,11 +392,6 @@ python sendspin_client.py
 2. Create a feature branch off `integration`
 3. Make your changes
 4. Submit a pull request against `integration`
-
----
-
-## Development Approach
-<img width="256" height="256" alt="image" src="https://github.com/user-attachments/assets/3e6903cf-2bfa-4f10-bc25-8bf3de5e2f3a" />
 
 ---
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,14 @@ fi
 
 # Use host's PipeWire/PulseAudio
 echo "Using host audio system (PipeWire/PulseAudio)..."
-if [ -S /run/user/1000/pulse/native ]; then
+if [ -n "${PULSE_SERVER:-}" ]; then
+    # Already set — by HA Supervisor (audio: true) or the ha-addon run.sh
+    echo "Audio bridge pre-configured: $PULSE_SERVER"
+elif [ -S /run/audio/pulse.sock ]; then
+    # HA OS audio bridge socket (Supervisor injects this path in some versions)
+    export PULSE_SERVER=unix:/run/audio/pulse.sock
+    echo "HA audio bridge socket found: /run/audio/pulse.sock"
+elif [ -S /run/user/1000/pulse/native ]; then
     echo "Host PulseAudio socket found"
     export PULSE_SERVER=unix:/run/user/1000/pulse/native
 elif [ -S /run/user/1000/pipewire-0 ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 echo "=== Starting Sendspin Client Container ==="
 

--- a/ha-addon/Dockerfile
+++ b/ha-addon/Dockerfile
@@ -1,0 +1,15 @@
+# Home Assistant Addon — thin wrapper over the main Sendspin Bluetooth Bridge image.
+# HA Supervisor will build this Dockerfile using the ha-addon/ directory as the
+# build context.  The base image already contains all Python source and
+# dependencies; we only add the HA-specific entry point.
+ARG BUILD_FROM=ghcr.io/loryanstrant/sendspin-client:latest
+FROM ${BUILD_FROM}
+
+# HA Supervisor expects the entry point to be at /run.sh by convention, but any
+# path is fine as long as config.yaml's `entrypoint` field (or CMD/ENTRYPOINT)
+# points to it.  We place it at /ha_run.sh to avoid collisions.
+COPY run.sh /ha_run.sh
+RUN chmod +x /ha_run.sh
+
+# Override the base image ENTRYPOINT so HA Supervisor starts our bootstrap.
+ENTRYPOINT ["/ha_run.sh"]

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,0 +1,35 @@
+---
+name: "Sendspin Bluetooth Bridge"
+version: "1.2.0"
+slug: "sendspin_bt_bridge"
+description: "Bridge Music Assistant Sendspin protocol to Bluetooth speakers"
+url: "https://github.com/loryanstrant/Sendspin-client"
+arch:
+  - aarch64
+  - amd64
+  - armv7
+startup: application
+boot: auto
+host_network: true
+privileged: true
+devices:
+  - /dev/bus/usb
+audio: true
+init: false
+ingress: true
+ingress_port: 8080
+panel_icon: mdi:bluetooth-audio
+
+options:
+  sendspin_server: "auto"
+  sendspin_port: 9000
+  bluetooth_devices: []
+
+schema:
+  sendspin_server: str
+  sendspin_port: int
+  bluetooth_devices:
+    - mac: str
+      player_name: str
+      adapter: str?
+      static_delay_ms: int?

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: "Sendspin Bluetooth Bridge"
-version: "1.2.0"
+version: "1.2.1"
 slug: "sendspin_bt_bridge"
 description: "Bridge Music Assistant Sendspin protocol to Bluetooth speakers"
 url: "https://github.com/trudenboy/sendspin-bt-bridge"

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -3,7 +3,7 @@ name: "Sendspin Bluetooth Bridge"
 version: "1.2.0"
 slug: "sendspin_bt_bridge"
 description: "Bridge Music Assistant Sendspin protocol to Bluetooth speakers"
-url: "https://github.com/loryanstrant/Sendspin-client"
+url: "https://github.com/trudenboy/sendspin-bt-bridge"
 arch:
   - aarch64
   - amd64

--- a/ha-addon/run.sh
+++ b/ha-addon/run.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Home Assistant Supervisor entry point for Sendspin Bluetooth Bridge
+# Reads /data/options.json provided by HA Supervisor, generates the app's
+# /config/config.json, configures audio, then execs the main entrypoint.
+
+set -euo pipefail
+
+echo "=== Sendspin Bluetooth Bridge - HA Addon Startup ==="
+
+OPTIONS_FILE="/data/options.json"
+
+if [ ! -f "$OPTIONS_FILE" ]; then
+    echo "ERROR: $OPTIONS_FILE not found (expected HA Supervisor options)"
+    exit 1
+fi
+
+echo "Reading addon options from $OPTIONS_FILE..."
+
+# Ensure config directory exists
+mkdir -p /config
+
+# Translate /data/options.json → /config/config.json
+python3 - <<'EOF'
+import json, sys
+
+with open('/data/options.json') as f:
+    opts = json.load(f)
+
+config = {
+    'SENDSPIN_SERVER': opts.get('sendspin_server', 'auto'),
+    'SENDSPIN_PORT':   str(opts.get('sendspin_port', 9000)),
+    'BLUETOOTH_DEVICES': opts.get('bluetooth_devices', []),
+    'TZ': opts.get('tz', 'UTC'),
+}
+
+# Preserve LAST_VOLUME if already saved by the app
+existing = {}
+try:
+    with open('/config/config.json') as f:
+        existing = json.load(f)
+except (FileNotFoundError, json.JSONDecodeError):
+    pass
+
+if 'LAST_VOLUME' in existing:
+    config['LAST_VOLUME'] = existing['LAST_VOLUME']
+
+with open('/config/config.json', 'w') as f:
+    json.dump(config, f, indent=2)
+
+print(f"Generated /config/config.json with {len(config['BLUETOOTH_DEVICES'])} device(s)")
+EOF
+
+# HA Supervisor audio bridge setup
+# Supervisor injects PULSE_SERVER when `audio: true` is set in config.yaml.
+# If it's already set, trust it. Otherwise fall back to known HA OS paths.
+if [ -n "${PULSE_SERVER:-}" ]; then
+    echo "Using HA Supervisor audio bridge: $PULSE_SERVER"
+elif [ -S /run/audio/pulse.sock ]; then
+    export PULSE_SERVER=unix:/run/audio/pulse.sock
+    echo "Using HA audio socket: /run/audio/pulse.sock"
+elif [ -S /run/user/1000/pulse/native ]; then
+    export PULSE_SERVER=unix:/run/user/1000/pulse/native
+    echo "Using PulseAudio socket: /run/user/1000/pulse/native"
+else
+    echo "WARNING: No audio socket found. Audio routing may not work."
+fi
+
+# Hand off to the main entrypoint (D-Bus, Bluetooth checks, app start)
+exec /app/entrypoint.sh

--- a/ha-addon/translations/en.yaml
+++ b/ha-addon/translations/en.yaml
@@ -1,0 +1,18 @@
+---
+configuration:
+  sendspin_server:
+    name: "Music Assistant server"
+    description: >-
+      Hostname or IP of the Music Assistant server. Use "auto" to discover
+      it automatically via mDNS (recommended for most setups).
+  sendspin_port:
+    name: "Sendspin port"
+    description: >-
+      WebSocket port exposed by the Music Assistant Sendspin provider.
+      The default (9000) matches the MA default; only change if you have
+      multiple instances or a custom port.
+  bluetooth_devices:
+    name: "Bluetooth devices"
+    description: >-
+      List of Bluetooth speakers to bridge. Each entry requires a MAC
+      address and a player name that will appear in Music Assistant.

--- a/lxc/install.sh
+++ b/lxc/install.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# install.sh - Sendspin Client LXC installer
+# Runs inside the LXC container as root. Idempotent (safe to re-run).
+# Usage: bash install.sh [--repo owner/repo] [--branch name]
+
+set -euo pipefail
+
+# ─── Colours ──────────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+BLUE='\033[0;34m'; CYAN='\033[0;36m'; BOLD='\033[1m'; NC='\033[0m'
+
+msg()  { echo -e "${CYAN}${BOLD}[Sendspin]${NC} $*"; }
+ok()   { echo -e "${GREEN}✓${NC} $*"; }
+warn() { echo -e "${YELLOW}⚠${NC}  $*"; }
+err()  { echo -e "${RED}✗${NC}  $*" >&2; }
+die()  { err "$*"; exit 1; }
+
+# ─── Argument parsing ─────────────────────────────────────────────────────────
+GITHUB_REPO="loryanstrant/sendspin-client"
+GITHUB_BRANCH="main"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)   GITHUB_REPO="$2";   shift 2 ;;
+    --branch) GITHUB_BRANCH="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+BASE="https://raw.githubusercontent.com/${GITHUB_REPO}/${GITHUB_BRANCH}"
+
+# ─── Pre-flight ───────────────────────────────────────────────────────────────
+[[ $EUID -eq 0 ]] || die "Must be run as root"
+
+msg "Sendspin Client LXC Installer"
+msg "Repo: ${GITHUB_REPO}  Branch: ${GITHUB_BRANCH}"
+echo ""
+
+# ─── 1. System packages ───────────────────────────────────────────────────────
+msg "Installing system packages..."
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y -qq \
+  python3 python3-pip \
+  bluetooth bluez bluez-tools \
+  pulseaudio pulseaudio-module-bluetooth \
+  alsa-utils dbus \
+  avahi-daemon avahi-utils libnss-mdns \
+  curl wget ca-certificates git jq tzdata procps
+ok "System packages installed"
+
+# ─── 2. App directory and files from GitHub ───────────────────────────────────
+msg "Downloading application files from GitHub..."
+mkdir -p /opt/sendspin-client
+
+wget -q "${BASE}/sendspin_client.py" -O /opt/sendspin-client/sendspin_client.py
+wget -q "${BASE}/web_interface.py"   -O /opt/sendspin-client/web_interface.py
+wget -q "${BASE}/requirements.txt"   -O /opt/sendspin-client/requirements.txt
+chmod +x /opt/sendspin-client/sendspin_client.py
+ok "Application files downloaded"
+
+# ─── 3. Python dependencies ───────────────────────────────────────────────────
+msg "Installing Python dependencies..."
+pip3 install --break-system-packages -q -r /opt/sendspin-client/requirements.txt
+ok "Python dependencies installed"
+
+# ─── 4. Config directory ──────────────────────────────────────────────────────
+msg "Setting up config directory..."
+mkdir -p /config
+
+if [[ ! -f /config/config.json ]]; then
+  cat > /config/config.json <<'EOF'
+{
+  "SENDSPIN_NAME": "Sendspin-LXC",
+  "SENDSPIN_SERVER": "auto",
+  "BLUETOOTH_MAC": "",
+  "TZ": "UTC"
+}
+EOF
+  ok "Default config.json written to /config/config.json"
+else
+  ok "config.json already exists — skipping"
+fi
+
+# ─── 5. PulseAudio system user ────────────────────────────────────────────────
+msg "Setting up pulse system user..."
+if ! id pulse &>/dev/null; then
+  useradd --system --home-dir /var/run/pulse --shell /bin/false --comment "PulseAudio system user" pulse
+  ok "Created pulse system user"
+else
+  ok "pulse user already exists — skipping"
+fi
+
+usermod -aG bluetooth pulse 2>/dev/null || true
+usermod -aG audio    pulse 2>/dev/null || true
+
+mkdir -p /var/run/pulse
+chown pulse:pulse /var/run/pulse
+chmod 755 /var/run/pulse
+ok "pulse user configured (bluetooth + audio groups)"
+
+# ─── 6. PulseAudio system configuration ──────────────────────────────────────
+msg "Writing PulseAudio system configuration..."
+mkdir -p /etc/pulse/client.conf.d
+
+cat > /etc/pulse/system.pa <<'EOF'
+# /etc/pulse/system.pa
+# PulseAudio system-mode configuration for Sendspin LXC deployment
+
+.ifexists module-udev-detect.so
+    load-module module-udev-detect
+.endif
+
+.ifexists module-bluetooth-policy.so
+    load-module module-bluetooth-policy
+.endif
+
+.ifexists module-bluetooth-discover.so
+    load-module module-bluetooth-discover
+.endif
+
+.ifexists module-native-protocol-unix.so
+    load-module module-native-protocol-unix auth-anonymous=1 socket=/var/run/pulse/native
+.endif
+
+.ifexists module-native-protocol-tcp.so
+    load-module module-native-protocol-tcp auth-ip-acl=127.0.0.1 auth-anonymous=1
+.endif
+
+.ifexists module-stream-restore.so
+    load-module module-stream-restore restore_device=false
+.endif
+
+.ifexists module-device-restore.so
+    load-module module-device-restore
+.endif
+
+.ifexists module-card-restore.so
+    load-module module-card-restore
+.endif
+EOF
+
+cat > /etc/pulse/client.conf.d/00-no-autospawn.conf <<'EOF'
+autospawn = no
+daemon-binary = /bin/true
+EOF
+
+ok "PulseAudio configuration written"
+
+# ─── 7. D-Bus policy for PulseAudio ↔ BlueZ ──────────────────────────────────
+msg "Writing D-Bus policy for PulseAudio Bluetooth access..."
+cat > /etc/dbus-1/system.d/pulseaudio-bluetooth.conf <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <policy user="pulse">
+    <allow own="org.pulseaudio.Server"/>
+    <allow send_destination="org.bluez"/>
+    <allow send_interface="org.bluez.MediaEndpoint1"/>
+    <allow send_interface="org.bluez.MediaTransport1"/>
+    <allow receive_sender="org.bluez"/>
+  </policy>
+  <policy context="default">
+    <allow send_destination="org.pulseaudio.Server"/>
+  </policy>
+</busconfig>
+EOF
+ok "D-Bus policy written"
+
+# ─── 8. Environment variables ─────────────────────────────────────────────────
+msg "Setting environment variables in /etc/environment..."
+
+set_env_var() {
+  local key="$1" val="$2"
+  if grep -q "^${key}=" /etc/environment 2>/dev/null; then
+    sed -i "s|^${key}=.*|${key}=${val}|" /etc/environment
+  else
+    echo "${key}=${val}" >> /etc/environment
+  fi
+}
+
+set_env_var "PULSE_SERVER"  "unix:/var/run/pulse/native"
+set_env_var "CONFIG_DIR"    "/config"
+set_env_var "WEB_PORT"      "8080"
+ok "Environment variables set"
+
+# ─── 9. Systemd units ─────────────────────────────────────────────────────────
+msg "Installing systemd service units..."
+
+cat > /etc/systemd/system/pulseaudio-system.service <<'EOF'
+[Unit]
+Description=PulseAudio System-Mode Daemon (Sendspin)
+After=dbus.service
+Requires=dbus.service
+Before=bluetooth.service sendspin-client.service
+
+[Service]
+Type=notify
+ExecStart=/usr/bin/pulseaudio --system --realtime --disallow-exit --no-cpu-limit --log-target=journal
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=5
+User=pulse
+Group=pulse
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+NoNewPrivileges=yes
+ProtectHome=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+RestrictNamespaces=yes
+RestrictRealtime=no
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat > /etc/systemd/system/sendspin-client.service <<'EOF'
+[Unit]
+Description=Sendspin Client (Music Assistant Player with Bluetooth)
+Documentation=https://github.com/loryanstrant/sendspin-client
+After=network-online.target dbus.service bluetooth.service pulseaudio-system.service avahi-daemon.service
+Wants=network-online.target
+Requires=pulseaudio-system.service dbus.service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+Environment=PYTHONUNBUFFERED=1
+ExecStartPre=/bin/sleep 3
+ExecStart=/usr/bin/python3 /opt/sendspin-client/sendspin_client.py
+WorkingDirectory=/opt/sendspin-client
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=sendspin-client
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+ok "Systemd units installed"
+
+# ─── 10. Enable and start services ───────────────────────────────────────────
+msg "Enabling and starting services..."
+systemctl daemon-reload
+
+for svc in dbus bluetooth avahi-daemon pulseaudio-system sendspin-client; do
+  systemctl enable "$svc" 2>/dev/null || warn "Could not enable $svc (may not exist yet)"
+done
+
+# Start in dependency order
+for svc in dbus bluetooth avahi-daemon pulseaudio-system sendspin-client; do
+  if systemctl is-active --quiet "$svc" 2>/dev/null; then
+    ok "$svc already running"
+  else
+    systemctl start "$svc" 2>/dev/null && ok "$svc started" || warn "$svc failed to start (check: journalctl -u $svc)"
+  fi
+done
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo -e "${GREEN}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${GREEN}${BOLD}  Sendspin Client installed successfully!${NC}"
+echo -e "${GREEN}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""
+
+# Detect container IP
+CONTAINER_IP=$(hostname -I 2>/dev/null | awk '{print $1}' || echo "<container-ip>")
+echo -e "  ${BOLD}Web UI:${NC}        http://${CONTAINER_IP}:8080"
+echo -e "  ${BOLD}Config file:${NC}   /config/config.json"
+echo -e "  ${BOLD}App logs:${NC}      journalctl -u sendspin-client -f"
+echo ""
+echo -e "  ${BOLD}Key commands:${NC}"
+echo -e "    systemctl status sendspin-client"
+echo -e "    systemctl restart sendspin-client"
+echo -e "    pactl list sinks short"
+echo -e "    bluetoothctl scan on"
+echo ""
+echo -e "  ${YELLOW}Note:${NC} Config changes require:"
+echo -e "    systemctl restart sendspin-client"
+echo ""

--- a/lxc/proxmox-create.sh
+++ b/lxc/proxmox-create.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# proxmox-create.sh - Create a Sendspin Client LXC container on Proxmox VE
+# Run as root on the Proxmox host.
+# Inspired by tteck/Proxmox community scripts.
+
+set -euo pipefail
+
+# ─── Colours & helpers ────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+BLUE='\033[0;34m'; CYAN='\033[0;36m'; BOLD='\033[1m'; NC='\033[0m'
+
+msg()    { echo -e "${CYAN}${BOLD}[Sendspin]${NC} $*"; }
+ok()     { echo -e "  ${GREEN}✓${NC} $*"; }
+warn()   { echo -e "  ${YELLOW}⚠${NC}  $*"; }
+err()    { echo -e "  ${RED}✗${NC}  $*" >&2; }
+die()    { err "$*"; exit 1; }
+prompt() { echo -e "  ${BLUE}?${NC}  $*"; }
+
+header() {
+  echo ""
+  echo -e "${CYAN}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+  echo -e "${CYAN}${BOLD}  Sendspin Client — Proxmox LXC Installer${NC}"
+  echo -e "${CYAN}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+  echo ""
+}
+
+spinner() {
+  local pid=$1 msg=${2:-"Working..."}
+  local frames=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏')
+  local i=0
+  while kill -0 "$pid" 2>/dev/null; do
+    printf "\r  ${CYAN}%s${NC}  %s" "${frames[$((i % ${#frames[@]}))]}" "$msg"
+    (( i++ )) || true
+    sleep 0.1
+  done
+  printf "\r%-60s\r" " "
+}
+
+ask() {
+  # ask VAR "Prompt" "default"
+  local var="$1" msg="$2" default="${3:-}"
+  if [[ -n "$default" ]]; then
+    prompt "${msg} [${BOLD}${default}${NC}]: "
+  else
+    prompt "${msg}: "
+  fi
+  read -r "$var" </dev/tty
+  if [[ -z "${!var}" && -n "$default" ]]; then
+    printf -v "$var" '%s' "$default"
+  fi
+}
+
+ask_yesno() {
+  local var="$1" msg="$2" default="${3:-y}"
+  local yn_display
+  if [[ "$default" == "y" ]]; then yn_display="Y/n"; else yn_display="y/N"; fi
+  prompt "${msg} [${BOLD}${yn_display}${NC}]: "
+  local answer
+  read -r answer </dev/tty
+  answer="${answer:-$default}"
+  if [[ "$answer" =~ ^[Yy] ]]; then printf -v "$var" 'y'; else printf -v "$var" 'n'; fi
+}
+
+# ─── Pre-flight checks ────────────────────────────────────────────────────────
+header
+
+msg "Running pre-flight checks..."
+
+[[ $EUID -eq 0 ]]         || die "Must be run as root"
+command -v pvesh &>/dev/null || die "pvesh not found — is this a Proxmox VE host?"
+command -v pct   &>/dev/null || die "pct not found — is this a Proxmox VE host?"
+command -v pveam &>/dev/null || die "pveam not found — is this a Proxmox VE host?"
+ok "Proxmox VE host confirmed"
+
+# ─── Interactive prompts ──────────────────────────────────────────────────────
+msg "Container configuration"
+echo ""
+
+# Next available CTID
+NEXT_ID=$(pvesh get /cluster/nextid 2>/dev/null || echo "100")
+
+ask CTID         "Container ID"                      "$NEXT_ID"
+ask HOSTNAME     "Hostname"                          "sendspin"
+ask RAM          "RAM (MB)"                          "512"
+ask DISK         "Disk size (GB)"                    "4"
+ask CORES        "CPU cores"                         "2"
+ask STORAGE      "Storage pool"                      "local-lvm"
+ask BRIDGE       "Network bridge"                    "vmbr0"
+ask IP           "IP address (CIDR, or 'dhcp')"      "dhcp"
+
+if [[ "$IP" != "dhcp" ]]; then
+  ask GATEWAY    "Gateway"                           ""
+fi
+
+ask GITHUB_REPO  "GitHub repo (owner/repo)"          "loryanstrant/sendspin-client"
+ask GITHUB_BRANCH "Branch"                           "main"
+
+ask_yesno USB_BT "Pass through USB Bluetooth adapter?" "y"
+
+echo ""
+warn "You will be prompted to set the LXC root password."
+echo ""
+
+# ─── Debian 12 template ───────────────────────────────────────────────────────
+msg "Checking for Debian 12 template..."
+
+TEMPLATE=$(pveam available --section system 2>/dev/null \
+  | grep "debian-12" | sort -V | tail -1 | awk '{print $2}')
+
+if [[ -z "$TEMPLATE" ]]; then
+  die "No Debian 12 template found in pveam. Run: pveam update"
+fi
+
+ok "Found template: ${TEMPLATE}"
+
+# Check if already downloaded
+if ! pveam list local 2>/dev/null | grep -q "$TEMPLATE"; then
+  msg "Downloading template ${TEMPLATE}..."
+  pveam update &>/dev/null &
+  spinner $! "Updating template list..."
+  pveam download local "$TEMPLATE" &
+  spinner $! "Downloading ${TEMPLATE}..."
+  wait
+  ok "Template downloaded"
+else
+  ok "Template already present"
+fi
+
+TEMPLATE_PATH="local:vztmpl/${TEMPLATE}"
+
+# ─── Create container ─────────────────────────────────────────────────────────
+msg "Creating LXC container ${CTID}..."
+
+NET_OPTS="name=eth0,bridge=${BRIDGE}"
+if [[ "$IP" == "dhcp" ]]; then
+  NET_OPTS="${NET_OPTS},ip=dhcp"
+else
+  NET_OPTS="${NET_OPTS},ip=${IP}"
+  if [[ -n "${GATEWAY:-}" ]]; then
+    NET_OPTS="${NET_OPTS},gw=${GATEWAY}"
+  fi
+fi
+
+pct create "$CTID" "$TEMPLATE_PATH" \
+  --hostname     "$HOSTNAME"        \
+  --memory       "$RAM"             \
+  --cores        "$CORES"           \
+  --rootfs       "${STORAGE}:${DISK}" \
+  --net0         "$NET_OPTS"        \
+  --unprivileged 0                  \
+  --features     nesting=1          \
+  --onboot       1                  \
+  --ostype       debian             \
+  --password \
+  2>&1
+
+ok "Container ${CTID} created"
+
+# ─── LXC config — cgroup rules & USB passthrough ─────────────────────────────
+msg "Adding cgroup device rules to container config..."
+
+LXC_CONF="/etc/pve/lxc/${CTID}.conf"
+
+cat >> "$LXC_CONF" <<'EOF'
+# Bluetooth HCI devices
+lxc.cgroup2.devices.allow: c 166:* rwm
+# Input devices
+lxc.cgroup2.devices.allow: c 13:* rwm
+# USB device tree (bind mount)
+lxc.mount.entry: /dev/bus/usb dev/bus/usb none bind,optional,create=dir 0 0
+EOF
+
+if [[ "${USB_BT}" == "y" ]]; then
+  cat >> "$LXC_CONF" <<'EOF'
+# USB devices (for USB Bluetooth adapter passthrough)
+lxc.cgroup2.devices.allow: c 189:* rwm
+EOF
+  ok "USB Bluetooth cgroup rules added"
+fi
+
+ok "cgroup device rules written to ${LXC_CONF}"
+
+# ─── Start container ──────────────────────────────────────────────────────────
+msg "Starting container ${CTID}..."
+pct start "$CTID"
+ok "Container started"
+
+msg "Waiting for container to be ready..."
+sleep 5
+
+# ─── Run install.sh inside container ─────────────────────────────────────────
+msg "Downloading install.sh from GitHub..."
+
+INSTALL_URL="https://raw.githubusercontent.com/${GITHUB_REPO}/${GITHUB_BRANCH}/lxc/install.sh"
+
+pct exec "$CTID" -- bash -c "curl -fsSL '${INSTALL_URL}' -o /root/install.sh 2>/dev/null || wget -q '${INSTALL_URL}' -O /root/install.sh"
+pct exec "$CTID" -- chmod +x /root/install.sh
+ok "install.sh downloaded into container"
+
+msg "Running install.sh inside container ${CTID}..."
+echo ""
+pct exec "$CTID" -- bash /root/install.sh --repo "$GITHUB_REPO" --branch "$GITHUB_BRANCH"
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo -e "${GREEN}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${GREEN}${BOLD}  LXC container created and configured!${NC}"
+echo -e "${GREEN}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""
+
+# Attempt to resolve container IP for summary
+CONTAINER_IP=$(pct exec "$CTID" -- hostname -I 2>/dev/null | awk '{print $1}' || echo "<container-ip>")
+
+echo -e "  ${BOLD}Container ID:${NC}   ${CTID}"
+echo -e "  ${BOLD}Hostname:${NC}       ${HOSTNAME}"
+echo -e "  ${BOLD}IP address:${NC}     ${CONTAINER_IP}"
+echo -e "  ${BOLD}Web UI:${NC}         http://${CONTAINER_IP}:8080"
+echo ""
+echo -e "  ${BOLD}Next steps:${NC}"
+echo -e "    1. Open the web UI and set your Bluetooth MAC address"
+echo -e "    2. Restart the service: ${CYAN}pct exec ${CTID} -- systemctl restart sendspin-client${NC}"
+echo ""
+echo -e "  ${BOLD}Useful commands:${NC}"
+echo -e "    # Enter the container:"
+echo -e "    ${CYAN}pct enter ${CTID}${NC}"
+echo ""
+echo -e "    # View logs:"
+echo -e "    ${CYAN}pct exec ${CTID} -- journalctl -u sendspin-client -f${NC}"
+echo ""
+echo -e "    # Pair a Bluetooth speaker:"
+echo -e "    ${CYAN}pct exec ${CTID} -- bluetoothctl${NC}"
+echo -e "    ${BLUE}  > scan on${NC}"
+echo -e "    ${BLUE}  > pair <MAC>${NC}"
+echo -e "    ${BLUE}  > trust <MAC>${NC}"
+echo -e "    ${BLUE}  > connect <MAC>${NC}"
+echo ""
+echo -e "  ${YELLOW}Note:${NC} Config changes → ${CYAN}pct exec ${CTID} -- systemctl restart sendspin-client${NC}"
+echo ""

--- a/lxc/pulse-system.pa
+++ b/lxc/pulse-system.pa
@@ -1,0 +1,35 @@
+# /etc/pulse/system.pa
+# PulseAudio system-mode configuration for Sendspin LXC deployment
+# Written by install.sh - do not edit manually
+
+.ifexists module-udev-detect.so
+    load-module module-udev-detect
+.endif
+
+.ifexists module-bluetooth-policy.so
+    load-module module-bluetooth-policy
+.endif
+
+.ifexists module-bluetooth-discover.so
+    load-module module-bluetooth-discover
+.endif
+
+.ifexists module-native-protocol-unix.so
+    load-module module-native-protocol-unix auth-anonymous=1 socket=/var/run/pulse/native
+.endif
+
+.ifexists module-native-protocol-tcp.so
+    load-module module-native-protocol-tcp auth-ip-acl=127.0.0.1 auth-anonymous=1
+.endif
+
+.ifexists module-stream-restore.so
+    load-module module-stream-restore restore_device=false
+.endif
+
+.ifexists module-device-restore.so
+    load-module module-device-restore
+.endif
+
+.ifexists module-card-restore.so
+    load-module module-card-restore
+.endif

--- a/lxc/pulse-system.pa
+++ b/lxc/pulse-system.pa
@@ -7,7 +7,7 @@
 .endif
 
 .ifexists module-bluetooth-policy.so
-    load-module module-bluetooth-policy
+    load-module module-bluetooth-policy auto_switch=never
 .endif
 
 .ifexists module-bluetooth-discover.so

--- a/lxc/pulseaudio-system.service
+++ b/lxc/pulseaudio-system.service
@@ -10,15 +10,10 @@ ExecStart=/usr/bin/pulseaudio --system --realtime --disallow-exit --no-cpu-limit
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartSec=5
-User=pulse
-Group=pulse
+Environment=PULSE_RUNTIME_PATH=/var/run/pulse
 LockPersonality=yes
-MemoryDenyWriteExecute=yes
-NoNewPrivileges=yes
-ProtectHome=yes
-ProtectKernelModules=yes
-ProtectKernelTunables=yes
-RestrictNamespaces=yes
+NoNewPrivileges=no
+ProtectHome=no
 RestrictRealtime=no
 
 [Install]

--- a/lxc/pulseaudio-system.service
+++ b/lxc/pulseaudio-system.service
@@ -2,15 +2,17 @@
 Description=PulseAudio System-Mode Daemon (Sendspin)
 After=dbus.service
 Requires=dbus.service
-Before=bluetooth.service sendspin-client.service
+Before=sendspin-client.service
 
 [Service]
 Type=notify
+Environment=PULSE_RUNTIME_PATH=/var/run/pulse
+# Use the host's D-Bus socket (bind-mounted at /bt-dbus) for Bluetooth A2DP
+Environment=DBUS_SYSTEM_BUS_ADDRESS=unix:path=/bt-dbus/system_bus_socket
 ExecStart=/usr/bin/pulseaudio --system --realtime --disallow-exit --no-cpu-limit --log-target=journal
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartSec=5
-Environment=PULSE_RUNTIME_PATH=/var/run/pulse
 LockPersonality=yes
 NoNewPrivileges=no
 ProtectHome=no

--- a/lxc/pulseaudio-system.service
+++ b/lxc/pulseaudio-system.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=PulseAudio System-Mode Daemon (Sendspin)
+After=dbus.service
+Requires=dbus.service
+Before=bluetooth.service sendspin-client.service
+
+[Service]
+Type=notify
+ExecStart=/usr/bin/pulseaudio --system --realtime --disallow-exit --no-cpu-limit --log-target=journal
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=5
+User=pulse
+Group=pulse
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+NoNewPrivileges=yes
+ProtectHome=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+RestrictNamespaces=yes
+RestrictRealtime=no
+
+[Install]
+WantedBy=multi-user.target

--- a/lxc/sendspin-client.service
+++ b/lxc/sendspin-client.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Sendspin Client (Music Assistant Player with Bluetooth)
+Documentation=https://github.com/loryanstrant/sendspin-client
+After=network-online.target dbus.service bluetooth.service pulseaudio-system.service avahi-daemon.service
+Wants=network-online.target
+Requires=pulseaudio-system.service dbus.service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+Environment=PYTHONUNBUFFERED=1
+ExecStartPre=/bin/sleep 3
+ExecStart=/usr/bin/python3 /opt/sendspin-client/sendspin_client.py
+WorkingDirectory=/opt/sendspin-client
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=sendspin-client
+
+[Install]
+WantedBy=multi-user.target

--- a/lxc/sendspin-client.service
+++ b/lxc/sendspin-client.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Sendspin Client (Music Assistant Player with Bluetooth)
 Documentation=https://github.com/loryanstrant/sendspin-client
-After=network-online.target dbus.service bluetooth.service pulseaudio-system.service avahi-daemon.service
+After=network-online.target dbus.service pulseaudio-system.service avahi-daemon.service
 Wants=network-online.target
 Requires=pulseaudio-system.service dbus.service
 
@@ -11,6 +11,8 @@ EnvironmentFile=/etc/environment
 Environment=PYTHONUNBUFFERED=1
 Environment=HOME=/root
 Environment=PULSE_SERVER=unix:/var/run/pulse/native
+# Use the host's D-Bus socket (bind-mounted at /bt-dbus) for Bluetooth control
+Environment=DBUS_SYSTEM_BUS_ADDRESS=unix:path=/bt-dbus/system_bus_socket
 Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ExecStartPre=/bin/sleep 3
 ExecStart=/usr/bin/python3 /opt/sendspin-client/sendspin_client.py

--- a/lxc/sendspin-client.service
+++ b/lxc/sendspin-client.service
@@ -9,6 +9,9 @@ Requires=pulseaudio-system.service dbus.service
 Type=simple
 EnvironmentFile=/etc/environment
 Environment=PYTHONUNBUFFERED=1
+Environment=HOME=/root
+Environment=PULSE_SERVER=unix:/var/run/pulse/native
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ExecStartPre=/bin/sleep 3
 ExecStart=/usr/bin/python3 /opt/sendspin-client/sendspin_client.py
 WorkingDirectory=/opt/sendspin-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 sendspin
-flask>=3.0.0
-flask-cors>=4.0.0
-psutil>=5.9.0
-python-dotenv>=1.0.0
-waitress>=2.1.2
-netifaces>=0.11.0
+flask>=3.0.0,<4.0.0
+flask-cors>=4.0.0,<5.0.0
+psutil>=5.9.0,<7.0.0
+python-dotenv>=1.0.0,<2.0.0
+waitress>=2.1.2,<4.0.0
+netifaces>=0.11.0,<1.0.0

--- a/sendspin_client.py
+++ b/sendspin_client.py
@@ -582,6 +582,12 @@ class SendspinClient:
     async def start_sendspin_process(self):
         """Start the sendspin CLI player"""
         try:
+            # If BT is connected but sink hasn't been configured yet (e.g. process restart
+            # triggered by _read_until_eof before monitor_and_reconnect runs configure),
+            # configure the audio sink now so bluetooth_sink_name is available.
+            if self.bt_manager and self.bt_manager.connected and not self.bluetooth_sink_name:
+                self.bt_manager.configure_bluetooth_audio()
+
             # Kill any existing process first to free the port
             if self.process and self.process.poll() is None:
                 logger.info(f"Stopping existing sendspin process (PID {self.process.pid}) before restart")

--- a/sendspin_client.py
+++ b/sendspin_client.py
@@ -24,6 +24,8 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+CLIENT_VERSION = "1.2.0"
+
 # Shared audio format cache — updated by whichever sendspin process logs
 # "Audio format: flac 48000Hz/24-bit/2ch"; read by all clients to fill in
 # format details when only "Stream started with codec X" was received.
@@ -565,6 +567,11 @@ class SendspinClient:
                 pulse_sink = f"bluez_sink.{pa_mac}.a2dp_sink"
                 env['PULSE_SINK'] = pulse_sink
                 logger.info(f"Routing audio to sink: {pulse_sink}")
+
+            # Override device info reported to Music Assistant
+            env['SENDSPIN_BRIDGE_MANUFACTURER'] = 'Sendspin'
+            env['SENDSPIN_BRIDGE_PRODUCT_NAME'] = 'Bluetooth Bridge'
+            env['SENDSPIN_BRIDGE_VERSION'] = CLIENT_VERSION
 
             # Start the sendspin process
             self.process = subprocess.Popen(

--- a/sendspin_client.py
+++ b/sendspin_client.py
@@ -645,9 +645,11 @@ class SendspinClient:
                     self.status['server_connected'] = True
 
                 # Sync volume changes to Bluetooth speaker
-                if line_str.startswith("Volume:") and self.bluetooth_sink_name:
+                # Handles "Volume: XX%" and "Server set player volume: XX%"
+                if ('Volume:' in line_str or 'player volume:' in line_str.lower()) and self.bluetooth_sink_name:
                     try:
-                        volume_part = line_str.split("Volume:")[-1].strip().rstrip('%')
+                        # Split on last colon to get the value regardless of prefix
+                        volume_part = line_str.rsplit(':', 1)[-1].strip().rstrip('%')
                         if volume_part and volume_part.isdigit():
                             volume_percent = int(volume_part)
                             self.status['volume'] = volume_percent

--- a/sendspin_client.py
+++ b/sendspin_client.py
@@ -830,8 +830,7 @@ async def main():
     bt_devices = config.get('BLUETOOTH_DEVICES', [])
     if not bt_devices:
         mac = config.get('BLUETOOTH_MAC', '')
-        prefix = config.get('SENDSPIN_NAME', 'Sendspin')
-        bt_devices = [{'mac': mac, 'adapter': '', 'player_name': f'{prefix} Player'}]
+        bt_devices = [{'mac': mac, 'adapter': '', 'player_name': 'Sendspin Player'}]
 
     logger.info(f"Starting {len(bt_devices)} player instance(s)")
     if server_host and server_host.lower() not in ['auto', 'discover', '']:
@@ -844,8 +843,7 @@ async def main():
     for i, device in enumerate(bt_devices):
         mac = device.get('mac', '')
         adapter = device.get('adapter', '')
-        prefix = config.get('SENDSPIN_NAME', 'Sendspin')
-        player_name = device.get('player_name') or f'{prefix} Player'
+        player_name = device.get('player_name') or 'Sendspin Player'
         # 'listen_port' is the preferred key; 'port' kept for backward compat
         listen_port = int(device.get('listen_port') or device.get('port') or base_listen_port + i)
         listen_host = device.get('listen_host')
@@ -906,7 +904,6 @@ def load_config():
     config_file = config_dir / 'config.json'
     
     default_config = {
-        'SENDSPIN_NAME': f'Sendspin-{socket.gethostname()}',
         'SENDSPIN_SERVER': 'auto',
         'SENDSPIN_PORT': 9000,
         'BLUETOOTH_MAC': '',
@@ -914,7 +911,7 @@ def load_config():
         'TZ': 'Australia/Melbourne',
     }
 
-    allowed_keys = {'SENDSPIN_NAME', 'SENDSPIN_SERVER', 'SENDSPIN_PORT', 'BLUETOOTH_MAC',
+    allowed_keys = {'SENDSPIN_SERVER', 'SENDSPIN_PORT', 'BLUETOOTH_MAC',
                     'BLUETOOTH_DEVICES', 'TZ', 'LAST_VOLUME'}
 
     if config_file.exists():

--- a/sendspin_client.py
+++ b/sendspin_client.py
@@ -56,6 +56,7 @@ class BluetoothManager:
         self.connected = False
         self.last_check = 0
         self.check_interval = 10  # Check every 10 seconds
+        self.bt_manufacturer: Optional[str] = None  # resolved once on first connect
 
         # Resolve adapter name to MAC for reliable 'select' in bridged D-Bus setups.
         # In LXC containers, 'select hci0' fails ("Controller hci0 not available");
@@ -111,6 +112,59 @@ class BluetoothManager:
             logger.error(f"Bluetoothctl error: {e}")
             return False, str(e)
     
+    def _fetch_manufacturer(self) -> Optional[str]:
+        """Get manufacturer name from BT DeviceID profile via host's pairing data."""
+        # The host's /var/lib/bluetooth/ is mounted read-only at /var/lib/bluetooth-bt/
+        # in the LXC container (bind mount added to lxc.conf).
+        adapter_mac = self._adapter_select or self.adapter
+        if not adapter_mac:
+            return None
+        info_path = f"/var/lib/bluetooth-bt/{adapter_mac}/{self.mac_address}/info"
+        try:
+            vendor_id = None
+            source = None
+            with open(info_path) as f:
+                for line in f:
+                    line = line.strip()
+                    if line.startswith('Vendor='):
+                        vendor_id = int(line.split('=', 1)[1])
+                    elif line.startswith('Source='):
+                        source = int(line.split('=', 1)[1])
+            if vendor_id is None:
+                return None
+            # Source=2 → USB VID; Source=1 → Bluetooth SIG company ID
+            # Look up USB vendor IDs in /usr/share/misc/usb.ids (vendor lines: "XXXX  Name")
+            # Chip/SoC vendors that appear in DeviceID but are not useful device manufacturers
+            CHIP_VENDORS = {
+                'linux foundation', 'cambridge silicon radio', 'csr plc',
+                'qualcomm', 'qualcomm technologies', 'broadcom',
+                'texas instruments', 'nordic semiconductor', 'silicon labs',
+                'cypress semiconductor', 'microchip technology',
+            }
+            if source == 2:
+                hex_vid = f"{vendor_id:04x}"
+                usb_ids = '/usr/share/misc/usb.ids'
+                try:
+                    with open(usb_ids) as f:
+                        for line in f:
+                            if line.startswith(hex_vid + '  '):
+                                name = line[len(hex_vid):].strip()
+                                if name and name.lower() not in CHIP_VENDORS:
+                                    return name
+                                return None
+                except OSError:
+                    pass
+            # Bluetooth SIG company IDs (small hardcoded table for consumer device brands)
+            BT_COMPANIES = {
+                0x004C: 'Apple', 0x012D: 'Sony', 0x0075: 'Samsung',
+                0x01D8: 'Bose', 0x0131: 'LG Electronics',
+            }
+            if source == 1 and vendor_id in BT_COMPANIES:
+                return BT_COMPANIES[vendor_id]
+        except Exception as e:
+            logger.debug(f"Manufacturer fetch failed for {self.mac_address}: {e}")
+        return None
+
     def check_bluetooth_available(self) -> bool:
         """Check if Bluetooth is available on the system"""
         try:
@@ -318,6 +372,10 @@ class BluetoothManager:
         if self.is_device_connected():
             logger.info("Device already connected")
             self.connected = True
+            if self.bt_manufacturer is None:
+                self.bt_manufacturer = self._fetch_manufacturer()
+                if self.bt_manufacturer:
+                    logger.info(f"BT manufacturer: {self.bt_manufacturer}")
             # Ensure audio is configured
             self.configure_bluetooth_audio()
             return True
@@ -343,6 +401,10 @@ class BluetoothManager:
             if self.is_device_connected():
                 logger.info("Successfully connected to Bluetooth speaker")
                 self.connected = True
+                if self.bt_manufacturer is None:
+                    self.bt_manufacturer = self._fetch_manufacturer()
+                    if self.bt_manufacturer:
+                        logger.info(f"BT manufacturer: {self.bt_manufacturer}")
                 # Configure audio routing
                 self.configure_bluetooth_audio()
                 return True
@@ -569,7 +631,12 @@ class SendspinClient:
                 logger.info(f"Routing audio to sink: {pulse_sink}")
 
             # Override device info reported to Music Assistant
-            env['SENDSPIN_BRIDGE_MANUFACTURER'] = 'Sendspin'
+            if self.bt_manager and self.bt_manager.bt_manufacturer is None:
+                self.bt_manager.bt_manufacturer = self.bt_manager._fetch_manufacturer()
+                if self.bt_manager.bt_manufacturer:
+                    logger.info(f"BT manufacturer: {self.bt_manager.bt_manufacturer}")
+            bt_mfr = (self.bt_manager.bt_manufacturer if self.bt_manager else None) or 'Sendspin'
+            env['SENDSPIN_BRIDGE_MANUFACTURER'] = bt_mfr
             env['SENDSPIN_BRIDGE_PRODUCT_NAME'] = 'Bluetooth Bridge'
             env['SENDSPIN_BRIDGE_VERSION'] = CLIENT_VERSION
 

--- a/sendspin_client.py
+++ b/sendspin_client.py
@@ -25,7 +25,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-CLIENT_VERSION = "1.2.0"
+CLIENT_VERSION = "1.2.1"
 
 # Per-player audio format cache — keyed by player_name.
 # Updated when a full "Audio format: flac 48000Hz/24-bit/2ch" line is received;

--- a/sendspin_client.py
+++ b/sendspin_client.py
@@ -830,8 +830,8 @@ async def main():
     bt_devices = config.get('BLUETOOTH_DEVICES', [])
     if not bt_devices:
         mac = config.get('BLUETOOTH_MAC', '')
-        name = config.get('SENDSPIN_NAME', f'Sendspin-{socket.gethostname()}')
-        bt_devices = [{'mac': mac, 'adapter': '', 'player_name': name}]
+        prefix = config.get('SENDSPIN_NAME', 'Sendspin')
+        bt_devices = [{'mac': mac, 'adapter': '', 'player_name': f'{prefix} Player'}]
 
     logger.info(f"Starting {len(bt_devices)} player instance(s)")
     if server_host and server_host.lower() not in ['auto', 'discover', '']:
@@ -844,8 +844,8 @@ async def main():
     for i, device in enumerate(bt_devices):
         mac = device.get('mac', '')
         adapter = device.get('adapter', '')
-        player_name = (device.get('player_name') or
-                       config.get('SENDSPIN_NAME', f'Sendspin-{socket.gethostname()}'))
+        prefix = config.get('SENDSPIN_NAME', 'Sendspin')
+        player_name = device.get('player_name') or f'{prefix} Player'
         # 'listen_port' is the preferred key; 'port' kept for backward compat
         listen_port = int(device.get('listen_port') or device.get('port') or base_listen_port + i)
         listen_host = device.get('listen_host')

--- a/sendspin_client.py
+++ b/sendspin_client.py
@@ -603,6 +603,14 @@ class SendspinClient:
                 # "INFO:aiosendspin.client.client:Stream started with codec flac"
                 if 'Stream STARTED' in line_str or 'Stream started with codec' in line_str:
                     self.status['playing'] = True
+                    # Extract codec from "Stream started with codec flac"
+                    if 'Stream started with codec' in line_str:
+                        try:
+                            codec = line_str.split('Stream started with codec')[-1].strip()
+                            if codec:
+                                self.status['audio_format'] = codec
+                        except Exception:
+                            pass
                 elif 'Stream STOPPED' in line_str or 'MPRIS interface stopped' in line_str:
                     self.status['playing'] = False
 

--- a/sendspin_client.py
+++ b/sendspin_client.py
@@ -429,6 +429,8 @@ class SendspinClient:
             'current_track': None,
             'current_artist': None,
             'volume': 100,
+            'muted': False,
+            'audio_format': None,
             'ip_address': self.get_ip_address(),
             'hostname': socket.gethostname(),
             'last_error': None,
@@ -600,6 +602,14 @@ class SendspinClient:
                     self.status['playing'] = True
                 elif 'Stream STOPPED' in line_str or 'MPRIS interface stopped' in line_str:
                     self.status['playing'] = False
+
+                # Parse audio format: "Audio format: flac 48000Hz/24-bit/2ch"
+                if 'Audio format:' in line_str:
+                    try:
+                        fmt = line_str.split('Audio format:')[-1].strip()
+                        self.status['audio_format'] = fmt
+                    except Exception:
+                        pass
 
                 # Track server connection — actual sendspin output:
                 # "INFO:sendspin.daemon.daemon:Server connected"

--- a/web_interface.py
+++ b/web_interface.py
@@ -482,8 +482,8 @@ HTML_TEMPLATE = """
         <summary>&#9881;&#65039; Configuration</summary>
         <form id="config-form">
             <div class="form-group">
-                <label>Server (use &#8216;auto&#8217; for mDNS discovery)</label>
-                <input type="text" name="SENDSPIN_SERVER" required>
+                <label>Music Assistant server &mdash; IP/hostname, or <code>auto</code> to discover via mDNS</label>
+                <input type="text" name="SENDSPIN_SERVER" placeholder="auto" required>
             </div>
 
             <div class="form-group">

--- a/web_interface.py
+++ b/web_interface.py
@@ -36,7 +36,7 @@ CONFIG_FILE = CONFIG_DIR / 'config.json'
 
 # Default configuration
 DEFAULT_CONFIG = {
-    'SENDSPIN_NAME': 'Sendspin-Player',
+    'SENDSPIN_NAME': 'Sendspin',
     'SENDSPIN_SERVER': 'auto',
     'BLUETOOTH_MAC': '',
     'BLUETOOTH_DEVICES': [],
@@ -482,8 +482,8 @@ HTML_TEMPLATE = """
         <summary>&#9881;&#65039; Configuration</summary>
         <form id="config-form">
             <div class="form-group">
-                <label>Player Name (global default)</label>
-                <input type="text" name="SENDSPIN_NAME" id="cfg-sendspin-name" placeholder="Sendspin-Player">
+                <label>Player Name Prefix</label>
+                <input type="text" name="SENDSPIN_NAME" id="cfg-sendspin-name" placeholder="Sendspin">
             </div>
             <div class="form-group">
                 <label>Server (use &#8216;auto&#8217; for mDNS discovery)</label>

--- a/web_interface.py
+++ b/web_interface.py
@@ -352,22 +352,20 @@ HTML_TEMPLATE = """
     <!-- Header -->
     <div class="header">
         <h1>&#127925; Sendspin Client</h1>
-        <div class="version-info" id="version-display">
-            <div>{{ VERSION }}</div>
-            <div>{{ BUILD_DATE }}</div>
+        <div style="text-align:right;">
+            <div class="version-info" id="version-display">
+                <div>{{ VERSION }}</div>
+                <div>{{ BUILD_DATE }}</div>
+            </div>
+            <div id="system-info" style="font-size:12px;color:#9ca3af;margin-top:4px;line-height:1.6;"></div>
         </div>
     </div>
 
     <!-- Restart banner -->
     <div id="restart-banner" class="restart-banner"></div>
 
-    <!-- Status grid: system info + device cards (populated by JS) -->
-    <div class="status-grid" id="status-grid">
-        <div class="status-card">
-            <div class="status-label" style="font-size:14px;color:#666;margin-bottom:8px;">System</div>
-            <div id="container-info" style="font-size:13px;color:#333;line-height:1.7;">Loading&#8230;</div>
-        </div>
-    </div>
+    <!-- Status grid: device cards (populated by JS) -->
+    <div class="status-grid" id="status-grid"></div>
 
     <!-- Configuration -->
     <div class="config-section">
@@ -464,11 +462,11 @@ async function updateStatus() {
         var status = await resp.json();
 
         var info = [];
-        if (status.hostname)   info.push('Host: ' + status.hostname);
-        if (status.ip_address) info.push('IP: ' + status.ip_address);
-        if (status.uptime)     info.push('Uptime: ' + status.uptime);
-        document.getElementById('container-info').innerHTML =
-            info.length ? info.join('<br>') : '&mdash;';
+        if (status.hostname)   info.push(escHtml(status.hostname));
+        if (status.ip_address) info.push(escHtml(status.ip_address));
+        if (status.uptime)     info.push('up ' + escHtml(status.uptime));
+        var sysEl = document.getElementById('system-info');
+        if (sysEl) sysEl.innerHTML = info.join(' &middot; ');
 
         var devices = status.devices || [status];
         lastDevices = devices;

--- a/web_interface.py
+++ b/web_interface.py
@@ -1784,7 +1784,17 @@ def api_config():
 
     elif request.method == 'POST':
         config = request.get_json()
+        # Preserve runtime-managed keys not sent by the UI
         CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        if CONFIG_FILE.exists():
+            try:
+                with open(CONFIG_FILE) as f:
+                    existing = json.load(f)
+                for key in ('LAST_VOLUMES', 'LAST_VOLUME'):
+                    if key in existing and key not in config:
+                        config[key] = existing[key]
+            except Exception:
+                pass
         with open(CONFIG_FILE, 'w') as f:
             json.dump(config, f, indent=2)
         return jsonify({'success': True})

--- a/web_interface.py
+++ b/web_interface.py
@@ -178,25 +178,33 @@ HTML_TEMPLATE = """
 
         /* Status grid */
         .status-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-            gap: 20px;
-            margin-bottom: 20px;
+            display: flex; flex-direction: column;
+            gap: 12px; margin-bottom: 20px;
         }
-        .status-card, .device-card {
-            background: white; border-radius: 10px; padding: 20px;
+        .device-card {
+            background: white; border-radius: 10px; padding: 16px 20px;
             box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+            display: flex; align-items: center; gap: 0;
+        }
+        .device-card-identity {
+            min-width: 180px; max-width: 220px; padding-right: 20px;
+            border-right: 1px solid #e5e7eb; margin-right: 0; flex-shrink: 0;
         }
         .device-card-title {
-            font-size: 16px; font-weight: 700; color: #667eea; margin-bottom: 2px;
+            font-size: 15px; font-weight: 700; color: #667eea; margin-bottom: 2px;
         }
         .device-mac {
             font-size: 11px; color: #9ca3af; font-family: 'Courier New', monospace;
-            margin-bottom: 14px;
         }
-        .device-rows { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
-        .device-rows .status-label { font-size: 12px; color: #666; margin-bottom: 3px; }
-        .device-rows .status-value { font-size: 14px; font-weight: 600; color: #333; }
+        .device-rows {
+            display: flex; flex: 1; gap: 0;
+        }
+        .device-rows > div {
+            flex: 1; padding: 0 16px; border-right: 1px solid #e5e7eb;
+        }
+        .device-rows > div:last-child { border-right: none; }
+        .device-rows .status-label { font-size: 11px; color: #9ca3af; margin-bottom: 3px; text-transform: uppercase; letter-spacing: 0.04em; }
+        .device-rows .status-value { font-size: 13px; font-weight: 600; color: #333; }
 
         /* Status indicators */
         .status-indicator {
@@ -496,9 +504,11 @@ function buildDeviceCard(i) {
     card.className = 'device-card';
     card.id = 'device-card-' + i;
     card.innerHTML =
-        '<div class="device-card-title" id="dname-' + i + '">Device ' + (i+1) + '</div>' +
-        '<div class="device-mac" id="dmac-' + i + '"></div>' +
-        '<div class="device-url" id="durl-' + i + '" style="font-size:11px;color:#888;margin-bottom:8px;"></div>' +
+        '<div class="device-card-identity">' +
+          '<div class="device-card-title" id="dname-' + i + '">Device ' + (i+1) + '</div>' +
+          '<div class="device-mac" id="dmac-' + i + '"></div>' +
+          '<div id="durl-' + i + '" style="font-size:10px;color:#c4b5fd;margin-top:2px;word-break:break-all;"></div>' +
+        '</div>' +
         '<div class="device-rows">' +
           '<div>' +
             '<div class="status-label">Bluetooth</div>' +
@@ -519,8 +529,7 @@ function buildDeviceCard(i) {
           '<div>' +
             '<div class="status-label">Playback</div>' +
             '<div class="status-value" id="dplay-' + i + '">-</div>' +
-            '<div class="ts" id="dtrack-' + i + '"></div>' +
-            '<div class="ts" id="daudiofmt-' + i + '" style="color:#8b5cf6;margin-top:2px;"></div>' +
+            '<div class="ts" id="daudiofmt-' + i + '" style="color:#8b5cf6;"></div>' +
           '</div>' +
           '<div>' +
             '<div class="status-label">Volume</div>' +
@@ -530,8 +539,8 @@ function buildDeviceCard(i) {
                 'oninput="onVolumeInput(' + i + ', this.value)">' +
               '<span class="volume-pct" id="dvol-' + i + '">100%</span>' +
               '<button type="button" id="dmute-' + i + '" ' +
-                'style="margin-left:8px;padding:2px 8px;border:1px solid #d1d5db;border-radius:4px;' +
-                'background:white;cursor:pointer;font-size:13px;" ' +
+                'style="margin-left:6px;padding:2px 7px;border:1px solid #d1d5db;border-radius:4px;' +
+                'background:white;cursor:pointer;font-size:12px;" ' +
                 'title="Mute/Unmute">&#128264;</button>' +
             '</div>' +
           '</div>' +

--- a/web_interface.py
+++ b/web_interface.py
@@ -27,7 +27,7 @@ app = Flask(__name__)
 CORS(app)
 
 # Version information
-VERSION = "1.2.0"
+VERSION = "1.2.1"
 BUILD_DATE = "2026-02-28"
 
 # Configuration file path

--- a/web_interface.py
+++ b/web_interface.py
@@ -758,7 +758,7 @@ async function startBtScan() {
     var listDiv = document.getElementById('scan-results-list');
 
     btn.disabled = true;
-    status.textContent = '\ud83d\udd04 Scanning\u2026 (~10s)';
+    status.textContent = '🔄 Scanning\u2026 (~10s)';
     box.style.display = 'none';
 
     try {
@@ -879,7 +879,7 @@ async function saveAndRestart() {
             banner.style.display = 'none';
             return;
         }
-        banner.textContent = '\ud83d\udd04 Restarting service\u2026';
+        banner.textContent = '🔄 Restarting service\u2026';
         try {
             await fetch('/api/restart', { method: 'POST' });
         } catch (_) { /* Service dropped connection — expected */ }
@@ -887,7 +887,7 @@ async function saveAndRestart() {
         await new Promise(function(r) { setTimeout(r, 2500); });
 
         for (var attempt = 1; attempt <= 30; attempt++) {
-            banner.textContent = '\ud83d\udd04 Restarting\u2026 (' + attempt + 's)';
+            banner.textContent = '🔄 Restarting\u2026 (' + attempt + 's)';
             await new Promise(function(r) { setTimeout(r, 1000); });
             try {
                 var resp = await fetch('/api/status');

--- a/web_interface.py
+++ b/web_interface.py
@@ -613,7 +613,7 @@ function populateDeviceCard(i, dev) {
     // Mute button — attach handler once, update icon on every poll
     var muteBtn = document.getElementById('dmute-' + i);
     if (muteBtn) {
-        muteBtn.textContent = dev.muted ? '\uD83D\uDD07' : '\uD83D\uDD08';
+        muteBtn.textContent = dev.muted ? '\\uD83D\\uDD07' : '\\uD83D\\uDD08';
         muteBtn.title = dev.muted ? 'Unmute' : 'Mute';
         muteBtn.style.background = dev.muted ? '#fee2e2' : 'white';
         if (!muteBtn._handlerSet) {
@@ -628,7 +628,7 @@ function populateDeviceCard(i, dev) {
                     if (d.success && lastDevices[i]) lastDevices[i].muted = d.muted;
                     var btn = document.getElementById('dmute-' + i);
                     if (btn) {
-                        btn.textContent = d.muted ? '\uD83D\uDD07' : '\uD83D\uDD08';
+                        btn.textContent = d.muted ? '\\uD83D\\uDD07' : '\\uD83D\\uDD08';
                         btn.title = d.muted ? 'Unmute' : 'Mute';
                         btn.style.background = d.muted ? '#fee2e2' : 'white';
                     }

--- a/web_interface.py
+++ b/web_interface.py
@@ -544,6 +544,11 @@ function buildDeviceCard(i) {
                 'title="Mute/Unmute">&#128264;</button>' +
             '</div>' +
           '</div>' +
+          '<div>' +
+            '<div class="status-label">Sync</div>' +
+            '<div class="status-value" id="dsync-' + i + '">&#8212;</div>' +
+            '<div class="ts" id="dsync-detail-' + i + '"></div>' +
+          '</div>' +
         '</div>';
     return card;
 }
@@ -608,6 +613,25 @@ function populateDeviceCard(i, dev) {
     // Audio format
     var fmtEl = document.getElementById('daudiofmt-' + i);
     if (fmtEl) fmtEl.textContent = dev.audio_format || '';
+
+    // Sync
+    var syncEl = document.getElementById('dsync-' + i);
+    var syncDetail = document.getElementById('dsync-detail-' + i);
+    if (syncEl) {
+        if (!dev.playing) {
+            syncEl.textContent = '\u2014';
+            syncEl.style.color = '#9ca3af';
+            if (syncDetail) syncDetail.textContent = '';
+        } else if (dev.reanchoring) {
+            syncEl.innerHTML = '<span style="color:#f59e0b;">&#9888; Re-anchoring</span>';
+            if (syncDetail) syncDetail.textContent = dev.last_sync_error_ms
+                ? 'Error: ' + dev.last_sync_error_ms.toFixed(1) + ' ms' : '';
+        } else {
+            syncEl.innerHTML = '<span style="color:#10b981;">&#10003; In sync</span>';
+            if (syncDetail) syncDetail.textContent = dev.reanchor_count
+                ? 'Re-anchors: ' + dev.reanchor_count : '';
+        }
+    }
 
     // Volume — only update if user isn't actively adjusting this slider
     if (dev.volume !== undefined && !volPending[i]) {

--- a/web_interface.py
+++ b/web_interface.py
@@ -7,6 +7,11 @@ Provides configuration and monitoring UI
 import json
 import logging
 import os
+import re
+import signal
+import subprocess
+import threading
+import time
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -32,7 +37,7 @@ CONFIG_FILE = CONFIG_DIR / 'config.json'
 # Default configuration
 DEFAULT_CONFIG = {
     'SENDSPIN_NAME': 'Sendspin-Player',
-    'SENDSPIN_SERVER': 'auto',  # Use 'auto' for mDNS discovery
+    'SENDSPIN_SERVER': 'auto',
     'BLUETOOTH_MAC': '',
     'BLUETOOTH_DEVICES': [],
     'TZ': 'Australia/Melbourne',
@@ -41,11 +46,13 @@ DEFAULT_CONFIG = {
 # Global clients list will be set by main
 _clients: list = []
 
+
 def set_client(client):
     """Set a single client reference (backward compat)"""
     global _clients
     _clients = [client]
     logger.info(f"Client reference set in web interface: {client}")
+
 
 def set_clients(clients):
     """Set multiple client references"""
@@ -53,53 +60,49 @@ def set_clients(clients):
     _clients = clients if clients else []
     logger.info(f"Client references set in web interface: {len(_clients)} client(s)")
 
+
+def _detect_runtime() -> str:
+    """Detect whether running under systemd (LXC) or Docker"""
+    if os.path.exists('/etc/systemd/system/sendspin-client.service'):
+        return 'systemd'
+    if os.path.exists('/run/systemd/system/sendspin-client.service'):
+        return 'systemd'
+    return 'docker'
+
+
 def get_client_status_for(client):
     """Get status dict for a specific client"""
     try:
         if client is None:
             return {
-                'connected': False,
-                'server_connected': False,
-                'bluetooth_connected': False,
-                'bluetooth_available': False,
-                'playing': False,
-                'error': 'Client not running',
-                'version': VERSION,
-                'build_date': BUILD_DATE,
+                'connected': False, 'server_connected': False,
+                'bluetooth_connected': False, 'bluetooth_available': False,
+                'playing': False, 'error': 'Client not running',
+                'version': VERSION, 'build_date': BUILD_DATE, 'bluetooth_mac': None,
             }
 
         if not hasattr(client, 'status'):
             return {
-                'connected': False,
-                'server_connected': False,
-                'bluetooth_connected': False,
-                'bluetooth_available': False,
-                'playing': False,
-                'error': 'Client initializing',
-                'version': VERSION,
-                'build_date': BUILD_DATE,
+                'connected': False, 'server_connected': False,
+                'bluetooth_connected': False, 'bluetooth_available': False,
+                'playing': False, 'error': 'Client initializing',
+                'version': VERSION, 'build_date': BUILD_DATE, 'bluetooth_mac': None,
             }
 
         status = client.status.copy()
 
-        # Calculate uptime
         if 'uptime_start' in status:
             uptime = datetime.now() - status['uptime_start']
             status['uptime'] = str(timedelta(seconds=int(uptime.total_seconds())))
             del status['uptime_start']
 
-        # Add version info
         status['version'] = VERSION
         status['build_date'] = BUILD_DATE
-
-        # Check if process is running
-        if client.process:
-            status['connected'] = client.process.poll() is None
-        else:
-            status['connected'] = False
-
-        # Add player_name for multi-device identification
+        status['connected'] = client.process.poll() is None if client.process else False
         status['player_name'] = getattr(client, 'player_name', None)
+
+        bt_mgr = getattr(client, 'bt_manager', None)
+        status['bluetooth_mac'] = bt_mgr.mac_address if bt_mgr else None
 
         logger.debug(f"Status retrieved: {status}")
         return status
@@ -107,35 +110,32 @@ def get_client_status_for(client):
     except Exception as e:
         logger.error(f"Error getting client status: {e}", exc_info=True)
         return {
-            'connected': False,
-            'server_connected': False,
-            'bluetooth_connected': False,
-            'bluetooth_available': False,
-            'playing': False,
-            'error': str(e),
-            'version': VERSION,
-            'build_date': BUILD_DATE,
+            'connected': False, 'server_connected': False,
+            'bluetooth_connected': False, 'bluetooth_available': False,
+            'playing': False, 'error': str(e),
+            'version': VERSION, 'build_date': BUILD_DATE, 'bluetooth_mac': None,
         }
+
 
 def get_client_status():
     """Get status from the first client (backward compat)"""
     if not _clients:
-        logger.warning("No clients registered")
         return {
-            'connected': False,
-            'server_connected': False,
-            'bluetooth_connected': False,
-            'bluetooth_available': False,
-            'playing': False,
-            'error': 'No clients',
-            'version': VERSION,
-            'build_date': BUILD_DATE,
+            'connected': False, 'server_connected': False,
+            'bluetooth_connected': False, 'bluetooth_available': False,
+            'playing': False, 'error': 'No clients',
+            'version': VERSION, 'build_date': BUILD_DATE, 'bluetooth_mac': None,
         }
     return get_client_status_for(_clients[0])
 
-# HTML Template
+
 def get_version_info():
     return {'VERSION': VERSION, 'BUILD_DATE': BUILD_DATE}
+
+
+# ---------------------------------------------------------------------------
+# HTML Template
+# ---------------------------------------------------------------------------
 
 HTML_TEMPLATE = """
 <!DOCTYPE html>
@@ -145,437 +145,965 @@ HTML_TEMPLATE = """
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sendspin Client</title>
     <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+        * { margin: 0; padding: 0; box-sizing: border-box; }
         body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+                         'Helvetica Neue', Arial, sans-serif;
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
             min-height: 100vh;
             padding: 20px;
         }
-        .container {
-            max-width: 1200px;
-            margin: 0 auto;
-        }
+        .container { max-width: 1200px; margin: 0 auto; }
+
+        /* Header */
         .header {
-            background: white;
-            border-radius: 10px;
-            padding: 20px;
-            margin-bottom: 20px;
-            box-shadow: 0 4px 6px rgba(0,0,0,0.1);
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
+            background: white; border-radius: 10px; padding: 20px;
+            margin-bottom: 20px; box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+            display: flex; justify-content: space-between; align-items: center;
         }
-        .header h1 {
-            color: #667eea;
-            font-size: 28px;
+        .header h1 { color: #667eea; font-size: 28px; }
+        .version-info { text-align: right; font-size: 12px; color: #666; }
+
+        /* Restart banner */
+        .restart-banner {
+            border-radius: 8px; padding: 12px 20px; margin-bottom: 20px;
+            font-size: 15px; font-weight: 500; text-align: center; display: none;
         }
-        .version-info {
-            text-align: right;
-            font-size: 12px;
-            color: #666;
-        }
+        .restart-banner.restarting { background: #fef3c7; color: #92400e; border: 1px solid #fcd34d; }
+        .restart-banner.online     { background: #d1fae5; color: #065f46; border: 1px solid #6ee7b7; }
+        .restart-banner.warning    { background: #fee2e2; color: #991b1b; border: 1px solid #fca5a5; }
+
+        /* Status grid */
         .status-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
             gap: 20px;
             margin-bottom: 20px;
         }
-        .status-card {
-            background: white;
-            border-radius: 10px;
-            padding: 20px;
+        .status-card, .device-card {
+            background: white; border-radius: 10px; padding: 20px;
             box-shadow: 0 4px 6px rgba(0,0,0,0.1);
         }
+        .device-card-title {
+            font-size: 16px; font-weight: 700; color: #667eea; margin-bottom: 2px;
+        }
+        .device-mac {
+            font-size: 11px; color: #9ca3af; font-family: 'Courier New', monospace;
+            margin-bottom: 14px;
+        }
+        .device-rows { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+        .device-rows .status-label { font-size: 12px; color: #666; margin-bottom: 3px; }
+        .device-rows .status-value { font-size: 14px; font-weight: 600; color: #333; }
+
+        /* Status indicators */
         .status-indicator {
-            display: inline-block;
-            width: 12px;
-            height: 12px;
-            border-radius: 50%;
-            margin-right: 10px;
+            display: inline-block; width: 10px; height: 10px;
+            border-radius: 50%; margin-right: 6px; flex-shrink: 0;
         }
-        .status-indicator.active {
-            background: #10b981;
-            box-shadow: 0 0 10px #10b981;
-        }
-        .status-indicator.inactive {
-            background: #ef4444;
-        }
-        .status-label {
-            font-size: 14px;
-            color: #666;
-            margin-bottom: 5px;
-        }
-        .status-value {
-            font-size: 20px;
-            font-weight: 600;
-            color: #333;
-        }
+        .status-indicator.active   { background: #10b981; box-shadow: 0 0 8px #10b981; }
+        .status-indicator.inactive { background: #ef4444; }
+
+        /* Volume slider */
+        .volume-row { display: flex; align-items: center; gap: 6px; }
+        .volume-slider { flex: 1; height: 4px; accent-color: #667eea; cursor: pointer; }
+        .volume-pct { min-width: 36px; text-align: right; font-size: 13px; color: #555; }
+
+        /* Config section */
         .config-section {
-            background: white;
-            border-radius: 10px;
-            padding: 20px;
-            box-shadow: 0 4px 6px rgba(0,0,0,0.1);
-            margin-bottom: 20px;
+            background: white; border-radius: 10px; padding: 20px;
+            box-shadow: 0 4px 6px rgba(0,0,0,0.1); margin-bottom: 20px;
         }
-        .config-section h2 {
-            color: #667eea;
-            margin-bottom: 15px;
-        }
-        .form-group {
-            margin-bottom: 15px;
-        }
-        .form-group label {
-            display: block;
-            margin-bottom: 5px;
-            color: #333;
-            font-weight: 500;
-        }
+        .config-section h2 { color: #667eea; margin-bottom: 15px; }
+        .form-group { margin-bottom: 15px; }
+        .form-group label { display: block; margin-bottom: 5px; color: #333; font-weight: 500; }
         .form-group input {
-            width: 100%;
-            padding: 10px;
-            border: 2px solid #e5e7eb;
-            border-radius: 5px;
-            font-size: 14px;
+            width: 100%; padding: 10px; border: 2px solid #e5e7eb;
+            border-radius: 5px; font-size: 14px;
         }
-        .form-group input:focus {
-            outline: none;
-            border-color: #667eea;
+        .form-group input:focus { outline: none; border-color: #667eea; }
+        .form-actions { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 15px; }
+
+        /* BT device table */
+        .bt-header {
+            display: grid; grid-template-columns: 1fr 1.3fr 0.9fr 30px;
+            gap: 8px; margin-bottom: 4px; padding: 0 2px;
+            font-size: 11px; font-weight: 600; color: #6b7280; text-transform: uppercase;
         }
+        .bt-device-row {
+            display: grid; grid-template-columns: 1fr 1.3fr 0.9fr 30px;
+            gap: 8px; align-items: center; margin-bottom: 8px;
+        }
+        .bt-device-row input, .bt-device-row select {
+            padding: 7px 10px; border: 2px solid #e5e7eb;
+            border-radius: 5px; font-size: 13px; background: white; width: 100%;
+        }
+        .bt-device-row input:focus, .bt-device-row select:focus {
+            outline: none; border-color: #667eea;
+        }
+        .bt-device-row input.invalid { border-color: #ef4444; background: #fef2f2; }
+        .btn-remove-dev {
+            background: #fee2e2; color: #ef4444; border: none; border-radius: 5px;
+            width: 30px; height: 34px; cursor: pointer; font-size: 18px; line-height: 1;
+        }
+        .btn-remove-dev:hover { background: #fecaca; }
+        .bt-toolbar { display: flex; align-items: center; gap: 8px; margin-top: 10px; flex-wrap: wrap; }
+        .scan-badge {
+            font-size: 13px; color: #6b7280;
+            display: flex; align-items: center; gap: 4px;
+        }
+        .scan-results-box {
+            margin-top: 10px; border: 1px solid #e5e7eb; border-radius: 6px;
+            padding: 10px; background: #f9fafb; display: none;
+        }
+        .scan-results-title { font-size: 12px; color: #6b7280; margin-bottom: 6px; }
+        .scan-result-item {
+            display: flex; align-items: center; gap: 10px;
+            padding: 5px 4px; border-bottom: 1px solid #f3f4f6; font-size: 13px;
+        }
+        .scan-result-item:last-child { border-bottom: none; }
+        .scan-result-mac { font-family: monospace; color: #9ca3af; font-size: 12px; }
+
+        /* Buttons */
         .btn {
-            background: #667eea;
-            color: white;
-            padding: 10px 20px;
-            border: none;
-            border-radius: 5px;
-            font-size: 16px;
-            cursor: pointer;
-            transition: background 0.3s;
+            background: #667eea; color: white; padding: 10px 20px;
+            border: none; border-radius: 5px; font-size: 15px;
+            cursor: pointer; transition: background 0.2s;
         }
-        .btn:hover {
-            background: #5568d3;
-        }
+        .btn:hover { background: #5568d3; }
+        .btn:disabled { opacity: 0.6; cursor: not-allowed; }
+        .btn-sm { padding: 7px 14px; font-size: 13px; }
+        .btn-restart { background: #f59e0b; }
+        .btn-restart:hover { background: #d97706; }
+        .btn-refresh { background: #10b981; }
+        .btn-refresh:hover { background: #059669; }
+        .btn-scan { background: #8b5cf6; }
+        .btn-scan:hover { background: #7c3aed; }
+
+        /* Logs section */
         .logs-section {
-            background: white;
-            border-radius: 10px;
-            padding: 20px;
+            background: white; border-radius: 10px; padding: 20px;
             box-shadow: 0 4px 6px rgba(0,0,0,0.1);
         }
-        .logs-section h2 {
-            color: #667eea;
-            margin-bottom: 15px;
+        .logs-section h2 { color: #667eea; margin-bottom: 15px; }
+        .logs-toolbar {
+            display: flex; align-items: center; gap: 10px;
+            flex-wrap: wrap; margin-bottom: 12px;
         }
         .logs-container {
-            background: #1e293b;
-            color: #e2e8f0;
-            padding: 15px;
-            border-radius: 5px;
-            font-family: 'Courier New', monospace;
-            font-size: 12px;
-            max-height: 400px;
-            overflow-y: auto;
+            background: #1e293b; color: #e2e8f0; padding: 15px; border-radius: 5px;
+            font-family: 'Courier New', monospace; font-size: 12px;
+            max-height: 400px; overflow-y: auto;
         }
-        .log-line {
-            margin-bottom: 5px;
+        .log-line { margin-bottom: 3px; line-height: 1.4; word-break: break-all; }
+        .log-error   { color: #f87171; }
+        .log-warning { color: #fbbf24; }
+        .log-info    { color: #e2e8f0; }
+        .log-debug   { color: #6b7280; }
+        .log-filter { display: inline-flex; gap: 4px; }
+        .filter-btn {
+            background: #374151; color: #9ca3af; padding: 4px 12px;
+            border: none; border-radius: 4px; cursor: pointer; font-size: 13px;
+            transition: background 0.2s;
         }
-        .refresh-btn {
-            background: #10b981;
-            margin-right: 10px;
+        .filter-btn:hover { background: #4b5563; color: white; }
+        .filter-btn.active { background: #667eea; color: white; }
+        .ts { font-size: 11px; color: #9ca3af; margin-top: 3px; }
+
+        /* Diagnostics section */
+        .diag-section {
+            background: white; border-radius: 10px; padding: 20px;
+            box-shadow: 0 4px 6px rgba(0,0,0,0.1); margin-bottom: 20px;
         }
-        .refresh-btn:hover {
-            background: #059669;
+        .diag-section summary {
+            color: #667eea; font-size: 20px; font-weight: 700;
+            cursor: pointer; list-style: none; user-select: none;
         }
+        .diag-section summary::-webkit-details-marker { display: none; }
+        .diag-section summary::before {
+            content: '\25B6';
+            display: inline-block; font-size: 13px; margin-right: 8px;
+            transition: transform 0.2s;
+        }
+        .diag-section[open] summary::before { transform: rotate(90deg); }
+        .diag-table { width: 100%; border-collapse: collapse; margin-top: 14px; }
+        .diag-table th {
+            font-size: 11px; font-weight: 600; color: #6b7280;
+            text-transform: uppercase; padding: 4px 8px; text-align: left;
+        }
+        .diag-table td { padding: 7px 8px; border-top: 1px solid #f3f4f6; font-size: 13px; }
+        .diag-dot {
+            display: inline-block; width: 9px; height: 9px;
+            border-radius: 50%; margin-right: 6px; vertical-align: middle;
+        }
+        .diag-dot.ok   { background: #10b981; box-shadow: 0 0 6px #10b981; }
+        .diag-dot.err  { background: #ef4444; }
+        .diag-dot.warn { background: #f59e0b; }
+
+        /* Timezone preview */
+        .tz-preview { font-size: 12px; color: #6b7280; white-space: nowrap; }
     </style>
 </head>
 <body>
-    <div class="container">
-        <div class="header">
-            <h1>🎵 Sendspin Client</h1>
-            <div class="version-info">
-                <div>Version: {{ VERSION }}</div>
-                <div>Build: {{ BUILD_DATE }}</div>
-            </div>
-        </div>
+<div class="container">
 
-        <div class="status-grid">
-            <div class="status-card">
-                <div class="status-label">Server Connection</div>
-                <div class="status-value">
-                    <span class="status-indicator" id="server-indicator"></span>
-                    <span id="server-status">Checking...</span>
-                </div>
-                <div style="font-size: 12px; color: #666; margin-top: 5px;" id="server-timestamp"></div>
-            </div>
-            <div class="status-card">
-                <div class="status-label">Bluetooth</div>
-                <div class="status-value">
-                    <span class="status-indicator" id="bt-indicator"></span>
-                    <span id="bt-status">Checking...</span>
-                </div>
-                <div style="font-size: 12px; color: #666; margin-top: 5px;" id="bt-timestamp"></div>
-            </div>
-            <div class="status-card">
-                <div class="status-label">Playback Status</div>
-                <div class="status-value" id="playback-status">Unknown</div>
-                <div style="font-size: 14px; color: #666; margin-top: 8px;" id="current-track"></div>
-                <div style="font-size: 14px; color: #666; margin-top: 5px;">Volume: <span id="volume-value">100</span>%</div>
-            </div>
-            <div class="status-card">
-                <div class="status-label">Container Info</div>
-                <div class="status-value" style="font-size: 14px;" id="container-info">Loading...</div>
-            </div>
-        </div>
-
-        <div class="config-section">
-            <h2>⚙️ Configuration</h2>
-            <form id="config-form">
-                <div class="form-group">
-                    <label>Player Name</label>
-                    <input type="text" name="SENDSPIN_NAME" required>
-                </div>
-                <div class="form-group">
-                    <label>Server (use 'auto' for mDNS discovery)</label>
-                    <input type="text" name="SENDSPIN_SERVER" required>
-                </div>
-
-                <div id="bt-devices-group" class="form-group" style="display:none;">
-                    <label>Bluetooth Devices (JSON array)</label>
-                    <textarea name="BLUETOOTH_DEVICES" rows="6" style="width:100%;padding:10px;border:2px solid #e5e7eb;border-radius:5px;font-family:monospace;font-size:13px;" placeholder='[{"mac":"AA:BB:CC:DD:EE:FF","adapter":"hci0","player_name":"My Speaker"}]'></textarea>
-                    <div style="font-size:12px;color:#666;margin-top:4px;">Each entry: <code>{"mac":"...", "adapter":"hci0", "player_name":"..."}</code></div>
-                </div>
-                <div id="bt-mac-group" class="form-group">
-                    <label>Bluetooth MAC Address</label>
-                    <input type="text" name="BLUETOOTH_MAC" placeholder="AA:BB:CC:DD:EE:FF">
-                </div>
-                <button type="submit" class="btn">Save Configuration</button>
-            </form>
-        </div>
-
-        <div class="logs-section">
-            <h2>📋 Logs</h2>
-            <button onclick="refreshLogs()" class="btn refresh-btn">Refresh Logs</button>
-            <button onclick="toggleAutoRefresh()" class="btn" id="auto-refresh-btn">Auto-Refresh: Off</button>
-            <div class="logs-container" id="logs"></div>
+    <!-- Header -->
+    <div class="header">
+        <h1>&#127925; Sendspin Client</h1>
+        <div class="version-info" id="version-display">
+            <div>{{ VERSION }}</div>
+            <div>{{ BUILD_DATE }}</div>
         </div>
     </div>
 
-    <script>
-        let autoRefreshLogs = false;
-        let refreshInterval;
+    <!-- Restart banner -->
+    <div id="restart-banner" class="restart-banner"></div>
 
-        async function updateStatus() {
-            try {
-                const response = await fetch('/api/status');
-                const status = await response.json();
+    <!-- Status grid: system info + device cards (populated by JS) -->
+    <div class="status-grid" id="status-grid">
+        <div class="status-card">
+            <div class="status-label" style="font-size:14px;color:#666;margin-bottom:8px;">System</div>
+            <div id="container-info" style="font-size:13px;color:#333;line-height:1.7;">Loading&#8230;</div>
+        </div>
+    </div>
 
-                // Server status
-                const serverIndicator = document.getElementById('server-indicator');
-                const serverStatus = document.getElementById('server-status');
-                if (status.server_connected) {
-                    serverIndicator.className = 'status-indicator active';
-                    serverStatus.textContent = 'Connected';
-                } else {
-                    serverIndicator.className = 'status-indicator inactive';
-                    serverStatus.textContent = status.error || 'Disconnected';
-                }
+    <!-- Configuration -->
+    <div class="config-section">
+        <h2>&#9881;&#65039; Configuration</h2>
+        <form id="config-form">
+            <div class="form-group">
+                <label>Player Name</label>
+                <input type="text" name="SENDSPIN_NAME" required>
+            </div>
+            <div class="form-group">
+                <label>Server (use &#8216;auto&#8217; for mDNS discovery)</label>
+                <input type="text" name="SENDSPIN_SERVER" required>
+            </div>
 
-                // Bluetooth status
-                const btIndicator = document.getElementById('bt-indicator');
-                const btStatus = document.getElementById('bt-status');
-                if (status.bluetooth_connected) {
-                    btIndicator.className = 'status-indicator active';
-                    btStatus.textContent = 'Connected';
-                } else if (status.bluetooth_available) {
-                    btIndicator.className = 'status-indicator inactive';
-                    btStatus.textContent = 'Disconnected';
-                } else {
-                    btIndicator.className = 'status-indicator inactive';
-                    btStatus.textContent = 'Not Available';
-                }
-                
-                // Bluetooth timestamp
-                if (status.bluetooth_connected_at) {
-                    const btTime = new Date(status.bluetooth_connected_at);
-                    document.getElementById('bt-timestamp').textContent = 
-                        `Since: ${btTime.toLocaleString()}`;
-                }
-                
-                // Server timestamp
-                if (status.server_connected_at) {
-                    const serverTime = new Date(status.server_connected_at);
-                    document.getElementById('server-timestamp').textContent = 
-                        `Since: ${serverTime.toLocaleString()}`;
-                }
+            <div class="form-group">
+                <label>Timezone</label>
+                <div style="display:flex;gap:10px;align-items:center;">
+                    <input type="text" name="TZ" placeholder="Australia/Melbourne" style="flex:1;"
+                        oninput="updateTzPreview()">
+                    <span id="tz-preview" class="tz-preview"></span>
+                </div>
+            </div>
 
-                // Playback status
-                document.getElementById('playback-status').textContent = 
-                    status.playing ? '▶️ Playing' : '⏸️ Stopped';
-                
-                // Current track
-                const trackElement = document.getElementById('current-track');
-                if (status.current_track) {
-                    trackElement.textContent = status.current_track;
-                    trackElement.style.display = 'block';
-                } else {
-                    trackElement.style.display = 'none';
-                }
-                
-                // Volume
-                if (status.volume !== undefined) {
-                    document.getElementById('volume-value').textContent = status.volume;
-                }
+            <!-- BT devices table (replaces raw JSON textarea + single MAC input) -->
+            <div class="form-group">
+                <label>Bluetooth Devices</label>
+                <div class="bt-header">
+                    <span>Player Name</span><span>MAC Address</span>
+                    <span>Adapter</span><span></span>
+                </div>
+                <div id="bt-devices-table"></div>
+                <div class="bt-toolbar">
+                    <button type="button" onclick="addBtDeviceRow()" class="btn btn-sm">+ Add Device</button>
+                    <button type="button" onclick="startBtScan()" class="btn btn-sm btn-scan" id="scan-btn">
+                        &#128269; Scan
+                    </button>
+                    <span id="scan-status" class="scan-badge"></span>
+                </div>
+                <div id="scan-results-box" class="scan-results-box">
+                    <div class="scan-results-title">Discovered devices &#8212; click to add:</div>
+                    <div id="scan-results-list"></div>
+                </div>
+            </div>
 
-                // Container info
-                const info = [];
-                if (status.hostname) info.push(`Host: ${status.hostname}`);
-                if (status.ip_address) info.push(`IP: ${status.ip_address}`);
-                if (status.uptime) info.push(`Uptime: ${status.uptime}`);
-                document.getElementById('container-info').innerHTML = info.join('<br>');
+            <div class="form-actions">
+                <button type="submit" class="btn">Save Configuration</button>
+                <button type="button" onclick="saveAndRestart()" class="btn btn-restart">
+                    Save &amp; Restart
+                </button>
+            </div>
+        </form>
+    </div>
 
-            } catch (error) {
-                console.error('Error updating status:', error);
+    <!-- Diagnostics (collapsible) -->
+    <details class="diag-section" id="diag-details" ontoggle="onDiagToggle(this)">
+        <summary>Diagnostics</summary>
+        <div id="diag-content"></div>
+    </details>
+
+    <!-- Logs -->
+    <div class="logs-section">
+        <h2>&#128203; Logs</h2>
+        <div class="logs-toolbar">
+            <button onclick="refreshLogs()" class="btn btn-refresh">Refresh Logs</button>
+            <button onclick="toggleAutoRefresh()" class="btn" id="auto-refresh-btn">Auto-Refresh: Off</button>
+            <div class="log-filter">
+                <button onclick="setLogLevel('all')"     id="filter-all"     class="filter-btn active">All</button>
+                <button onclick="setLogLevel('error')"   id="filter-error"   class="filter-btn">Error</button>
+                <button onclick="setLogLevel('warning')" id="filter-warning" class="filter-btn">Warning</button>
+                <button onclick="setLogLevel('info')"    id="filter-info"    class="filter-btn">Info</button>
+            </div>
+        </div>
+        <div class="logs-container" id="logs"></div>
+    </div>
+
+</div>
+
+<script>
+// ---- State ----
+var autoRefreshLogs = false;
+var autoRefreshInterval = null;
+var allLogs = [];
+var currentLogLevel = 'all';
+var btAdapters = [];
+var lastDevices = [];
+var volTimers = {};
+var volPending = {}; // deviceIndex -> true if user recently touched slider
+
+// ---- Status ----
+
+async function updateStatus() {
+    try {
+        var resp = await fetch('/api/status');
+        var status = await resp.json();
+
+        var info = [];
+        if (status.hostname)   info.push('Host: ' + status.hostname);
+        if (status.ip_address) info.push('IP: ' + status.ip_address);
+        if (status.uptime)     info.push('Uptime: ' + status.uptime);
+        document.getElementById('container-info').innerHTML =
+            info.length ? info.join('<br>') : '&mdash;';
+
+        var devices = status.devices || [status];
+        lastDevices = devices;
+        var grid = document.getElementById('status-grid');
+
+        devices.forEach(function(dev, i) {
+            var card = document.getElementById('device-card-' + i);
+            if (!card) {
+                card = buildDeviceCard(i);
+                grid.appendChild(card);
             }
-        }
-
-        async function loadConfig() {
-            try {
-                const response = await fetch('/api/config');
-                const config = await response.json();
-
-                // Handle BLUETOOTH_DEVICES vs BLUETOOTH_MAC
-                const devices = config.BLUETOOTH_DEVICES;
-                if (devices && Array.isArray(devices) && devices.length > 0) {
-                    document.getElementById('bt-devices-group').style.display = 'block';
-                    document.getElementById('bt-mac-group').style.display = 'none';
-                    const ta = document.querySelector('[name="BLUETOOTH_DEVICES"]');
-                    if (ta) ta.value = JSON.stringify(devices, null, 2);
-                } else {
-                    document.getElementById('bt-devices-group').style.display = 'none';
-                    document.getElementById('bt-mac-group').style.display = 'block';
-                }
-
-                Object.keys(config).forEach(key => {
-                    if (key === 'BLUETOOTH_DEVICES') return; // handled above
-                    const input = document.querySelector(`[name="${key}"]`);
-                    if (input) {
-                        input.value = config[key];
-                    }
-                });
-            } catch (error) {
-                console.error('Error loading config:', error);
-            }
-        }
-
-        async function refreshLogs() {
-            try {
-                const response = await fetch('/api/logs');
-                const data = await response.json();
-                const logsContainer = document.getElementById('logs');
-                logsContainer.innerHTML = data.logs.map(line => 
-                    `<div class="log-line">${line}</div>`
-                ).join('');
-                logsContainer.scrollTop = logsContainer.scrollHeight;
-            } catch (error) {
-                console.error('Error refreshing logs:', error);
-            }
-        }
-
-        function toggleAutoRefresh() {
-            autoRefreshLogs = !autoRefreshLogs;
-            const btn = document.getElementById('auto-refresh-btn');
-            
-            if (autoRefreshLogs) {
-                btn.textContent = 'Auto-Refresh: On';
-                btn.style.background = '#10b981';
-                refreshInterval = setInterval(refreshLogs, 2000);
-                refreshLogs();
-            } else {
-                btn.textContent = 'Auto-Refresh: Off';
-                btn.style.background = '#667eea';
-                clearInterval(refreshInterval);
-            }
-        }
-
-        document.getElementById('config-form').addEventListener('submit', async (e) => {
-            e.preventDefault();
-            const formData = new FormData(e.target);
-            const config = Object.fromEntries(formData);
-
-            // Parse BLUETOOTH_DEVICES textarea as JSON if present and non-empty
-            if (config.BLUETOOTH_DEVICES !== undefined) {
-                const raw = config.BLUETOOTH_DEVICES.trim();
-                if (raw) {
-                    try {
-                        config.BLUETOOTH_DEVICES = JSON.parse(raw);
-                    } catch (err) {
-                        alert('BLUETOOTH_DEVICES is not valid JSON: ' + err.message);
-                        return;
-                    }
-                } else {
-                    config.BLUETOOTH_DEVICES = [];
-                }
-            }
-
-            try {
-                const response = await fetch('/api/config', {
-                    method: 'POST',
-                    headers: {'Content-Type': 'application/json'},
-                    body: JSON.stringify(config)
-                });
-
-                if (response.ok) {
-                    alert('Configuration saved! Restart the container for changes to take effect.');
-                } else {
-                    alert('Failed to save configuration');
-                }
-            } catch (error) {
-                console.error('Error saving config:', error);
-                alert('Error saving configuration');
-            }
+            populateDeviceCard(i, dev);
         });
 
-        // Update status every 2 seconds
-        updateStatus();
-        setInterval(updateStatus, 2000);
+        // Remove stale cards
+        Array.from(grid.querySelectorAll('.device-card'))
+            .slice(devices.length)
+            .forEach(function(c) { c.remove(); });
 
-        // Load config on page load
-        loadConfig();
+    } catch (err) {
+        console.error('Status update failed:', err);
+    }
+}
 
-        // Load initial logs
+function buildDeviceCard(i) {
+    var card = document.createElement('div');
+    card.className = 'device-card';
+    card.id = 'device-card-' + i;
+    card.innerHTML =
+        '<div class="device-card-title" id="dname-' + i + '">Device ' + (i+1) + '</div>' +
+        '<div class="device-mac" id="dmac-' + i + '"></div>' +
+        '<div class="device-rows">' +
+          '<div>' +
+            '<div class="status-label">Bluetooth</div>' +
+            '<div class="status-value">' +
+              '<span class="status-indicator" id="dbt-ind-' + i + '"></span>' +
+              '<span id="dbt-txt-' + i + '">-</span>' +
+            '</div>' +
+            '<div class="ts" id="dbt-since-' + i + '"></div>' +
+          '</div>' +
+          '<div>' +
+            '<div class="status-label">Server</div>' +
+            '<div class="status-value">' +
+              '<span class="status-indicator" id="dsrv-ind-' + i + '"></span>' +
+              '<span id="dsrv-txt-' + i + '">-</span>' +
+            '</div>' +
+            '<div class="ts" id="dsrv-since-' + i + '"></div>' +
+          '</div>' +
+          '<div>' +
+            '<div class="status-label">Playback</div>' +
+            '<div class="status-value" id="dplay-' + i + '">-</div>' +
+            '<div class="ts" id="dtrack-' + i + '"></div>' +
+          '</div>' +
+          '<div>' +
+            '<div class="status-label">Volume</div>' +
+            '<div class="volume-row">' +
+              '<input type="range" min="0" max="100" value="100" ' +
+                'class="volume-slider" id="vslider-' + i + '" ' +
+                'oninput="onVolumeInput(' + i + ', this.value)">' +
+              '<span class="volume-pct" id="dvol-' + i + '">100%</span>' +
+            '</div>' +
+          '</div>' +
+        '</div>';
+    return card;
+}
+
+function populateDeviceCard(i, dev) {
+    var name = dev.player_name || ('Device ' + (i + 1));
+    document.getElementById('dname-' + i).textContent = name;
+
+    var mac = dev.bluetooth_mac || '';
+    document.getElementById('dmac-' + i).textContent = mac ? 'MAC: ' + mac : '';
+
+    // Bluetooth
+    var btInd   = document.getElementById('dbt-ind-' + i);
+    var btTxt   = document.getElementById('dbt-txt-' + i);
+    var btSince = document.getElementById('dbt-since-' + i);
+    if (dev.bluetooth_connected) {
+        btInd.className = 'status-indicator active';
+        btTxt.textContent = 'Connected';
+    } else if (dev.reconnecting) {
+        btInd.className = 'status-indicator inactive';
+        btTxt.textContent = 'Reconnecting\u2026' +
+            (dev.reconnect_attempt ? ' (' + dev.reconnect_attempt + ')' : '');
+    } else if (dev.bluetooth_available) {
+        btInd.className = 'status-indicator inactive';
+        btTxt.textContent = 'Disconnected';
+    } else {
+        btInd.className = 'status-indicator inactive';
+        btTxt.textContent = 'Not Available';
+    }
+    if (btSince) btSince.textContent = dev.bluetooth_connected_at
+        ? 'Since: ' + new Date(dev.bluetooth_connected_at).toLocaleString() : '';
+
+    // Server
+    var srvInd   = document.getElementById('dsrv-ind-' + i);
+    var srvTxt   = document.getElementById('dsrv-txt-' + i);
+    var srvSince = document.getElementById('dsrv-since-' + i);
+    if (dev.server_connected) {
+        srvInd.className = 'status-indicator active';
+        srvTxt.textContent = 'Connected';
+    } else {
+        srvInd.className = 'status-indicator inactive';
+        srvTxt.textContent = dev.error || 'Disconnected';
+    }
+    if (srvSince) srvSince.textContent = dev.server_connected_at
+        ? 'Since: ' + new Date(dev.server_connected_at).toLocaleString() : '';
+
+    // Playback
+    document.getElementById('dplay-' + i).textContent =
+        dev.playing ? '\u25b6\ufe0f Playing' : '\u23f8\ufe0f Stopped';
+    var trackEl = document.getElementById('dtrack-' + i);
+    if (trackEl) trackEl.textContent = dev.current_track || '';
+
+    // Volume — only update if user isn't actively adjusting this slider
+    if (dev.volume !== undefined && !volPending[i]) {
+        var slider = document.getElementById('vslider-' + i);
+        var volEl  = document.getElementById('dvol-' + i);
+        if (slider) slider.value = dev.volume;
+        if (volEl)  volEl.textContent = dev.volume + '%';
+    }
+}
+
+// ---- Volume slider ----
+
+function onVolumeInput(i, val) {
+    var volEl = document.getElementById('dvol-' + i);
+    if (volEl) volEl.textContent = val + '%';
+
+    // Mark pending so status poll doesn't overwrite while user drags
+    volPending[i] = true;
+    clearTimeout(volTimers[i]);
+    volTimers[i] = setTimeout(function() {
+        delete volPending[i];
+        sendVolume(i, parseInt(val, 10));
+    }, 300);
+}
+
+async function sendVolume(deviceIndex, vol) {
+    var dev = lastDevices[deviceIndex] || {};
+    try {
+        await fetch('/api/volume', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ volume: vol, player_name: dev.player_name || null }),
+        });
+    } catch (err) {
+        console.error('Volume set failed:', err);
+    }
+}
+
+// ---- Logs ----
+
+function escHtml(s) {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function getLogClass(line) {
+    var u = line.toUpperCase();
+    if (u.indexOf('ERROR') !== -1 || u.indexOf('CRITICAL') !== -1) return 'log-error';
+    if (u.indexOf('WARNING') !== -1 || u.indexOf('WARN') !== -1)   return 'log-warning';
+    if (u.indexOf(' INFO ') !== -1  || u.indexOf(' INFO\t') !== -1) return 'log-info';
+    if (u.indexOf('DEBUG') !== -1) return 'log-debug';
+    return '';
+}
+
+function renderLogs() {
+    var filtered = allLogs;
+    if (currentLogLevel === 'error') {
+        filtered = allLogs.filter(function(l) {
+            var u = l.toUpperCase();
+            return u.indexOf('ERROR') !== -1 || u.indexOf('CRITICAL') !== -1;
+        });
+    } else if (currentLogLevel === 'warning') {
+        filtered = allLogs.filter(function(l) {
+            var u = l.toUpperCase();
+            return u.indexOf('WARNING') !== -1 || u.indexOf('WARN') !== -1;
+        });
+    } else if (currentLogLevel === 'info') {
+        filtered = allLogs.filter(function(l) {
+            var u = l.toUpperCase();
+            return u.indexOf(' INFO ') !== -1 || u.indexOf(' INFO\t') !== -1;
+        });
+    }
+    var container = document.getElementById('logs');
+    container.innerHTML = filtered.map(function(line) {
+        return '<div class="log-line ' + getLogClass(line) + '">' + escHtml(line) + '</div>';
+    }).join('');
+    container.scrollTop = container.scrollHeight;
+}
+
+function setLogLevel(level) {
+    currentLogLevel = level;
+    document.querySelectorAll('.filter-btn').forEach(function(b) { b.classList.remove('active'); });
+    document.getElementById('filter-' + level).classList.add('active');
+    renderLogs();
+}
+
+async function refreshLogs() {
+    try {
+        var resp = await fetch('/api/logs?lines=150');
+        var data = await resp.json();
+        allLogs = data.logs || [];
+        renderLogs();
+    } catch (err) {
+        console.error('Error refreshing logs:', err);
+    }
+}
+
+function toggleAutoRefresh() {
+    autoRefreshLogs = !autoRefreshLogs;
+    var btn = document.getElementById('auto-refresh-btn');
+    if (autoRefreshLogs) {
+        btn.textContent = 'Auto-Refresh: On';
+        btn.style.background = '#10b981';
+        autoRefreshInterval = setInterval(refreshLogs, 2000);
         refreshLogs();
-    </script>
+    } else {
+        btn.textContent = 'Auto-Refresh: Off';
+        btn.style.background = '#667eea';
+        clearInterval(autoRefreshInterval);
+    }
+}
+
+// ---- BT Device Table ----
+
+async function loadBtAdapters() {
+    try {
+        var resp = await fetch('/api/bt/adapters');
+        var data = await resp.json();
+        btAdapters = data.adapters || [];
+    } catch (_) { btAdapters = []; }
+}
+
+function btAdapterOptions(selected) {
+    var opts = '<option value="">default</option>';
+    btAdapters.forEach(function(a) {
+        var label = a.id + (a.mac ? ' \u2014 ' + a.mac : '');
+        opts += '<option value="' + a.id + '"' +
+            (selected === a.id ? ' selected' : '') + '>' + label + '</option>';
+    });
+    return opts;
+}
+
+function addBtDeviceRow(name, mac, adapter) {
+    var tbody = document.getElementById('bt-devices-table');
+    var row = document.createElement('div');
+    row.className = 'bt-device-row';
+    row.innerHTML =
+        '<input type="text" placeholder="Player Name" class="bt-name" value="' +
+            escHtml(name || '') + '">' +
+        '<input type="text" placeholder="AA:BB:CC:DD:EE:FF" class="bt-mac" value="' +
+            escHtml(mac || '') + '">' +
+        '<select class="bt-adapter">' + btAdapterOptions(adapter || '') + '</select>' +
+        '<button type="button" class="btn-remove-dev" ' +
+            'onclick="this.closest(\'.bt-device-row\').remove()">\u00d7</button>';
+
+    row.querySelector('.bt-mac').addEventListener('input', function() {
+        var v = this.value.trim();
+        var valid = /^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$/.test(v);
+        this.classList.toggle('invalid', v !== '' && !valid);
+    });
+    tbody.appendChild(row);
+}
+
+function collectBtDevices() {
+    var devices = [];
+    document.querySelectorAll('#bt-devices-table .bt-device-row').forEach(function(row) {
+        var name    = row.querySelector('.bt-name').value.trim();
+        var mac     = row.querySelector('.bt-mac').value.trim().toUpperCase();
+        var adapter = row.querySelector('.bt-adapter').value;
+        if (mac) devices.push({ mac: mac, adapter: adapter, player_name: name });
+    });
+    return devices;
+}
+
+function populateBtDeviceRows(devices) {
+    document.getElementById('bt-devices-table').innerHTML = '';
+    devices.forEach(function(d) {
+        addBtDeviceRow(d.player_name || '', d.mac || '', d.adapter || '');
+    });
+}
+
+// ---- BT Scan ----
+
+async function startBtScan() {
+    var btn     = document.getElementById('scan-btn');
+    var status  = document.getElementById('scan-status');
+    var box     = document.getElementById('scan-results-box');
+    var listDiv = document.getElementById('scan-results-list');
+
+    btn.disabled = true;
+    status.textContent = '\ud83d\udd04 Scanning\u2026 (~10s)';
+    box.style.display = 'none';
+
+    try {
+        var resp = await fetch('/api/bt/scan', { method: 'POST' });
+        var data = await resp.json();
+        var devices = data.devices || [];
+
+        if (devices.length === 0) {
+            status.textContent = 'No devices found.';
+        } else {
+            status.textContent = 'Found ' + devices.length + ' device(s)';
+            listDiv.innerHTML = devices.map(function(d) {
+                var safeName = escHtml(d.name);
+                return '<div class="scan-result-item">' +
+                    '<span class="scan-result-mac">' + escHtml(d.mac) + '</span>' +
+                    '<span>' + safeName + '</span>' +
+                    '<button type="button" style="margin-left:auto;padding:3px 10px;' +
+                        'background:#667eea;color:white;border:none;border-radius:4px;' +
+                        'cursor:pointer;font-size:12px;" ' +
+                        'onclick="addFromScan(\'' + d.mac + '\',\'' +
+                        d.name.replace(/\\/g,'\\\\').replace(/'/g,"\\'") + '\')">' +
+                        'Add</button>' +
+                    '</div>';
+            }).join('');
+            box.style.display = 'block';
+        }
+    } catch (err) {
+        status.textContent = 'Scan failed: ' + err.message;
+    } finally {
+        btn.disabled = false;
+    }
+}
+
+function addFromScan(mac, name) {
+    addBtDeviceRow(name, mac, '');
+    document.getElementById('scan-results-box').style.display = 'none';
+    document.getElementById('scan-status').textContent = '';
+}
+
+// ---- Config ----
+
+async function saveConfig() {
+    var formData = new FormData(document.getElementById('config-form'));
+    var config = Object.fromEntries(formData);
+
+    // Collect BT devices from table rows (overrides anything from formData)
+    config.BLUETOOTH_DEVICES = collectBtDevices();
+    // Keep single BLUETOOTH_MAC for backward compat if exactly one device
+    if (config.BLUETOOTH_DEVICES.length === 1) {
+        config.BLUETOOTH_MAC = config.BLUETOOTH_DEVICES[0].mac;
+    } else {
+        config.BLUETOOTH_MAC = '';
+    }
+
+    try {
+        var resp = await fetch('/api/config', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(config),
+        });
+        return resp.ok;
+    } catch (err) {
+        console.error('Save config error:', err);
+        return false;
+    }
+}
+
+document.getElementById('config-form').addEventListener('submit', async function(e) {
+    e.preventDefault();
+    try {
+        var ok = await saveConfig();
+        if (ok) {
+            alert('Configuration saved! Use \u201cSave & Restart\u201d or restart the service for changes to take effect.');
+        } else {
+            alert('Failed to save configuration.');
+        }
+    } catch (err) {
+        alert('Error saving configuration: ' + err.message);
+    }
+});
+
+async function loadConfig() {
+    try {
+        var resp = await fetch('/api/config');
+        var config = await resp.json();
+
+        // Populate simple fields
+        ['SENDSPIN_NAME', 'SENDSPIN_SERVER', 'TZ'].forEach(function(key) {
+            var input = document.querySelector('[name="' + key + '"]');
+            if (input && config[key] !== undefined) input.value = config[key];
+        });
+        updateTzPreview();
+
+        // Populate BT device table
+        var devices = config.BLUETOOTH_DEVICES;
+        if (devices && Array.isArray(devices) && devices.length > 0) {
+            populateBtDeviceRows(devices);
+        } else if (config.BLUETOOTH_MAC) {
+            // Migrate single BLUETOOTH_MAC to table
+            addBtDeviceRow(config.SENDSPIN_NAME || '', config.BLUETOOTH_MAC, '');
+        }
+    } catch (err) {
+        console.error('Error loading config:', err);
+    }
+}
+
+// ---- Restart ----
+
+async function saveAndRestart() {
+    var banner = document.getElementById('restart-banner');
+    banner.style.display = 'block';
+    banner.className = 'restart-banner restarting';
+    banner.textContent = 'Saving configuration\u2026';
+
+    try {
+        var saved = await saveConfig();
+        if (!saved) {
+            banner.style.display = 'none';
+            return;
+        }
+        banner.textContent = '\ud83d\udd04 Restarting service\u2026';
+        try {
+            await fetch('/api/restart', { method: 'POST' });
+        } catch (_) { /* Service dropped connection — expected */ }
+
+        await new Promise(function(r) { setTimeout(r, 2500); });
+
+        for (var attempt = 1; attempt <= 30; attempt++) {
+            banner.textContent = '\ud83d\udd04 Restarting\u2026 (' + attempt + 's)';
+            await new Promise(function(r) { setTimeout(r, 1000); });
+            try {
+                var resp = await fetch('/api/status');
+                if (resp.ok) {
+                    banner.className = 'restart-banner online';
+                    banner.textContent = '\u2713 Service restarted successfully';
+                    setTimeout(function() { banner.style.display = 'none'; }, 3000);
+                    updateStatus();
+                    return;
+                }
+            } catch (_) { /* Not yet back */ }
+        }
+        banner.className = 'restart-banner warning';
+        banner.textContent = '\u26a0\ufe0f Service may still be restarting \u2014 check logs';
+
+    } catch (err) {
+        banner.className = 'restart-banner warning';
+        banner.textContent = '\u26a0\ufe0f Error: ' + err.message;
+    }
+}
+
+// ---- Timezone preview ----
+
+function updateTzPreview() {
+    var tzInput = document.querySelector('[name="TZ"]');
+    var preview = document.getElementById('tz-preview');
+    if (!tzInput || !preview) return;
+    var tz = tzInput.value.trim();
+    if (!tz) { preview.textContent = ''; return; }
+    try {
+        var now = new Date();
+        var formatted = now.toLocaleTimeString('en-AU', {
+            timeZone: tz, hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false
+        });
+        preview.textContent = 'Now: ' + formatted;
+        preview.style.color = '#6b7280';
+    } catch (_) {
+        preview.textContent = 'Invalid timezone';
+        preview.style.color = '#ef4444';
+    }
+}
+
+// Update TZ preview every second while panel is visible
+setInterval(updateTzPreview, 1000);
+
+// ---- Version ----
+
+async function loadVersionInfo() {
+    try {
+        var resp = await fetch('/api/version');
+        var data = await resp.json();
+        var el = document.getElementById('version-display');
+        if (!el) return;
+        var sha = data.git_sha && data.git_sha !== 'unknown'
+            ? '<div style="font-family:monospace;">' + escHtml(data.git_sha) + '</div>' : '';
+        el.innerHTML =
+            '<div>' + escHtml(data.version || '') + '</div>' +
+            sha +
+            '<div>' + escHtml(data.built_at || '') + '</div>';
+    } catch (_) { /* Keep static Jinja2-rendered values */ }
+}
+
+// ---- Diagnostics ----
+
+function onDiagToggle(el) {
+    if (el.open) {
+        var content = document.getElementById('diag-content');
+        if (!content.dataset.loaded) {
+            loadDiagnostics(content);
+        }
+    }
+}
+
+async function loadDiagnostics(contentEl) {
+    contentEl.innerHTML = '<span style="color:#6b7280;font-size:13px;">Loading&#8230;</span>';
+    try {
+        var resp = await fetch('/api/diagnostics');
+        var data = await resp.json();
+        contentEl.innerHTML = renderDiagnostics(data);
+        contentEl.dataset.loaded = '1';
+    } catch (err) {
+        contentEl.innerHTML =
+            '<span style="color:#ef4444;font-size:13px;">Error: ' + err.message + '</span>';
+    }
+}
+
+function dot(ok) {
+    return '<span class="diag-dot ' + (ok ? 'ok' : 'err') + '"></span>';
+}
+
+function renderDiagnostics(d) {
+    var rows = '';
+
+    rows += '<tr><td>Bluetooth daemon</td><td>' +
+        dot(d.bluetooth_daemon === 'active') + escHtml(d.bluetooth_daemon || 'unknown') +
+        '</td></tr>';
+
+    rows += '<tr><td>D-Bus socket</td><td>' +
+        dot(d.dbus_available) + (d.dbus_available ? 'Available' : 'Not found') +
+        '</td></tr>';
+
+    rows += '<tr><td>Audio server</td><td>' +
+        dot(d.pulseaudio && d.pulseaudio !== 'not available') +
+        escHtml(d.pulseaudio || 'unknown') + '</td></tr>';
+
+    (d.adapters || []).forEach(function(a, i) {
+        rows += '<tr><td>Adapter hci' + i + '</td><td>' +
+            escHtml(a.mac || '') + (a.default ? ' <span style="color:#6b7280;">(default)</span>' : '') +
+            (a.error ? ' <span style="color:#ef4444;">' + escHtml(a.error) + '</span>' : '') +
+            '</td></tr>';
+    });
+
+    var sinks = d.sinks || [];
+    rows += '<tr><td>BT audio sinks</td><td>' +
+        dot(sinks.length > 0) +
+        (sinks.length > 0 ? escHtml(sinks.join(', ')) : 'None') +
+        '</td></tr>';
+
+    (d.devices || []).forEach(function(dev) {
+        rows += '<tr><td>' + escHtml(dev.name || dev.mac || 'Unknown') + '</td><td>' +
+            dot(dev.connected) + (dev.connected ? 'Connected' : 'Disconnected') +
+            (dev.sink ? ' <span style="color:#6b7280;font-family:monospace;font-size:11px;">' +
+                escHtml(dev.sink) + '</span>' : '') +
+            (dev.last_error
+                ? '<br><span style="color:#ef4444;font-size:11px;">' +
+                  escHtml(dev.last_error) + '</span>' : '') +
+            '</td></tr>';
+    });
+
+    return '<table class="diag-table">' +
+        '<tr><th>Component</th><th>Status</th></tr>' +
+        rows + '</table>' +
+        '<div style="text-align:right;margin-top:8px;">' +
+          '<button type="button" onclick="reloadDiagnostics()" ' +
+          'style="font-size:12px;background:none;border:none;color:#667eea;cursor:pointer;">' +
+          '&#8635; Refresh</button></div>';
+}
+
+function reloadDiagnostics() {
+    var content = document.getElementById('diag-content');
+    delete content.dataset.loaded;
+    loadDiagnostics(content);
+}
+
+// ---- Init ----
+loadBtAdapters().then(function() {
+    loadConfig();   // populate adapter dropdowns after adapters are loaded
+});
+updateStatus();
+setInterval(updateStatus, 2000);
+refreshLogs();
+loadVersionInfo();
+</script>
 </body>
 </html>
 """
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
 
 @app.route('/')
 def index():
     """Render the main page"""
     return render_template_string(HTML_TEMPLATE, **get_version_info())
 
+
+@app.route('/api/restart', methods=['POST'])
+def api_restart():
+    """Restart the service (systemd or Docker)"""
+    runtime = _detect_runtime()
+    try:
+        if runtime == 'systemd':
+            def _do_systemd():
+                time.sleep(0.5)
+                subprocess.run(
+                    ['systemctl', 'restart', 'sendspin-client'],
+                    capture_output=True, timeout=10
+                )
+            threading.Thread(target=_do_systemd, daemon=True).start()
+        else:
+            def _do_docker():
+                time.sleep(0.5)
+                try:
+                    os.kill(1, signal.SIGTERM)
+                except ProcessLookupError:
+                    os.kill(os.getpid(), signal.SIGTERM)
+            threading.Thread(target=_do_docker, daemon=True).start()
+
+        return jsonify({'success': True, 'runtime': runtime})
+    except Exception as e:
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
 @app.route('/api/volume', methods=['POST'])
 def set_volume():
     """Set player volume"""
     try:
         data = request.get_json()
-        volume = data.get('volume', 100)
-        
-        # Validate volume
-        volume = max(0, min(100, int(volume)))
-        
-        # Get client and send volume command via pactl to both sendspin and bluetooth
-        client = _clients[0] if _clients else None
+        volume = max(0, min(100, int(data.get('volume', 100))))
+        player_name = data.get('player_name')
+
+        client = None
+        if player_name:
+            for c in _clients:
+                if getattr(c, 'player_name', None) == player_name:
+                    client = c
+                    break
+        if client is None and _clients:
+            client = _clients[0]
+
         if client and client.bluetooth_sink_name:
-            # Set Bluetooth speaker volume
             result = subprocess.run(
                 ['pactl', 'set-sink-volume', client.bluetooth_sink_name, f'{volume}%'],
-                capture_output=True,
-                text=True,
-                timeout=2
+                capture_output=True, text=True, timeout=2
             )
             if result.returncode == 0:
                 client.status['volume'] = volume
@@ -587,6 +1115,7 @@ def set_volume():
     except Exception as e:
         return jsonify({'success': False, 'error': str(e)}), 500
 
+
 @app.route('/api/status')
 def api_status():
     """API endpoint for status"""
@@ -594,56 +1123,232 @@ def api_status():
         return jsonify({'error': 'No clients'})
     if len(_clients) == 1:
         return jsonify(get_client_status_for(_clients[0]))
-    # Multi-client: return devices array + first client's fields at top level
     first = get_client_status_for(_clients[0])
     result = {**first, 'devices': [get_client_status_for(c) for c in _clients]}
     return jsonify(result)
+
 
 @app.route('/api/config', methods=['GET', 'POST'])
 def api_config():
     """API endpoint for configuration"""
     if request.method == 'GET':
-        # Load config
         if CONFIG_FILE.exists():
             with open(CONFIG_FILE) as f:
                 config = json.load(f)
         else:
             config = DEFAULT_CONFIG.copy()
         return jsonify(config)
-    
+
     elif request.method == 'POST':
-        # Save config
         config = request.get_json()
         CONFIG_DIR.mkdir(parents=True, exist_ok=True)
         with open(CONFIG_FILE, 'w') as f:
             json.dump(config, f, indent=2)
         return jsonify({'success': True})
 
+
 @app.route('/api/logs')
 def api_logs():
-    """API endpoint for logs"""
+    """Return real service logs (journalctl or docker logs)"""
+    lines = request.args.get('lines', 150, type=int)
     try:
-        # Read container logs
-        import subprocess
-        # Provide helpful message about viewing logs
-        logs = [
-            "Container logs are available via:",
-            "  - docker logs sendspin-client",
-            "  - docker compose logs",
-            "",
-            f"Web interface: v{VERSION} ({BUILD_DATE})",
-            "Status: Running normally"
-        ]
-        return jsonify({'logs': logs})
+        runtime = _detect_runtime()
+        if runtime == 'systemd':
+            result = subprocess.run(
+                ['journalctl', '-u', 'sendspin-client',
+                 '-n', str(lines), '--no-pager', '--output=short-iso'],
+                capture_output=True, text=True, timeout=10
+            )
+            log_lines = result.stdout.splitlines()
+            if not log_lines and result.stderr:
+                log_lines = result.stderr.splitlines()
+        else:
+            result = subprocess.run(
+                ['docker', 'logs', '--tail', str(lines), 'sendspin-client'],
+                capture_output=True, text=True, timeout=10
+            )
+            log_lines = (result.stdout + result.stderr).splitlines()
+
+        if not log_lines:
+            log_lines = ['(No logs available)']
+
+        return jsonify({'logs': log_lines, 'runtime': runtime})
     except Exception as e:
         logger.error(f"Error reading logs: {e}")
         return jsonify({'logs': [f'Error reading logs: {e}']})
+
+
+@app.route('/api/bt/adapters')
+def api_bt_adapters():
+    """List available Bluetooth adapters"""
+    try:
+        result = subprocess.run(
+            ['bash', '-c', 'bluetoothctl list 2>/dev/null'],
+            capture_output=True, text=True, timeout=5
+        )
+        adapters = []
+        for i, line in enumerate(result.stdout.splitlines()):
+            if 'Controller' not in line:
+                continue
+            parts = line.split()
+            mac = next(
+                (p for p in parts if len(p) == 17 and p.count(':') == 5), None
+            )
+            if mac:
+                mac_idx = parts.index(mac)
+                name_parts = [p for p in parts[mac_idx + 1:]
+                              if p not in ('[default]', 'default')]
+                name = ' '.join(name_parts).strip() or f'hci{i}'
+                adapters.append({'id': f'hci{i}', 'mac': mac, 'name': name})
+        return jsonify({'adapters': adapters})
+    except Exception as e:
+        return jsonify({'adapters': [], 'error': str(e)})
+
+
+@app.route('/api/bt/scan', methods=['POST'])
+def api_bt_scan():
+    """Scan for nearby Bluetooth devices (~10 second scan)"""
+    try:
+        result = subprocess.run(
+            ['bash', '-c',
+             'echo -e "power on\\nagent on\\nscan on\\n" | timeout 12 bluetoothctl 2>&1'],
+            capture_output=True, text=True, timeout=15
+        )
+        devices = []
+        seen: set = set()
+        pattern = re.compile(r'\[NEW\]\s+Device\s+([0-9A-Fa-f:]{17})\s+(.*)')
+        for line in result.stdout.splitlines():
+            m = pattern.search(line)
+            if m:
+                mac = m.group(1).upper()
+                name = m.group(2).strip()
+                if mac and mac not in seen:
+                    seen.add(mac)
+                    devices.append({'mac': mac, 'name': name or mac})
+        return jsonify({'devices': devices})
+    except Exception as e:
+        logger.error(f"BT scan failed: {e}")
+        return jsonify({'devices': [], 'error': str(e)})
+
+
+@app.route('/api/diagnostics')
+def api_diagnostics():
+    """Return structured health diagnostics"""
+    try:
+        diag: dict = {}
+
+        # Bluetooth daemon
+        try:
+            r = subprocess.run(
+                ['systemctl', 'is-active', 'bluetooth'],
+                capture_output=True, text=True, timeout=3
+            )
+            diag['bluetooth_daemon'] = r.stdout.strip() or 'unknown'
+        except Exception:
+            diag['bluetooth_daemon'] = 'unknown'
+
+        # D-Bus socket
+        dbus_env = os.environ.get('DBUS_SYSTEM_BUS_ADDRESS', '')
+        dbus_path = dbus_env.replace('unix:path=', '') if dbus_env else '/run/dbus/system_bus_socket'
+        diag['dbus_available'] = os.path.exists(dbus_path)
+
+        # Bluetooth adapters
+        try:
+            r = subprocess.run(
+                ['bash', '-c', 'bluetoothctl list 2>/dev/null'],
+                capture_output=True, text=True, timeout=5
+            )
+            adapters = []
+            for i, line in enumerate(r.stdout.splitlines()):
+                if 'Controller' not in line:
+                    continue
+                parts = line.split()
+                mac = next((p for p in parts if len(p) == 17 and p.count(':') == 5), '')
+                adapters.append({
+                    'id': f'hci{i}', 'mac': mac,
+                    'default': 'default' in line.lower(),
+                })
+            diag['adapters'] = adapters
+        except Exception as e:
+            diag['adapters'] = [{'error': str(e)}]
+
+        # PulseAudio / PipeWire
+        try:
+            r = subprocess.run(['pactl', 'info'], capture_output=True, text=True, timeout=3)
+            if r.returncode == 0:
+                diag['pulseaudio'] = next(
+                    (l.split(':', 1)[-1].strip() for l in r.stdout.splitlines()
+                     if 'Server Name' in l),
+                    'running'
+                )
+            else:
+                diag['pulseaudio'] = 'not available'
+        except Exception:
+            diag['pulseaudio'] = 'not available'
+
+        # BT audio sinks
+        try:
+            r = subprocess.run(
+                ['pactl', 'list', 'short', 'sinks'],
+                capture_output=True, text=True, timeout=3
+            )
+            diag['sinks'] = [
+                l.split()[1] for l in r.stdout.splitlines()
+                if 'bluez' in l.lower() and len(l.split()) > 1
+            ]
+        except Exception:
+            diag['sinks'] = []
+
+        # Per-device status (from cached status — fast, no bluetoothctl calls)
+        device_diag = []
+        for client in _clients:
+            bt_mgr = getattr(client, 'bt_manager', None)
+            device_diag.append({
+                'name': getattr(client, 'player_name', 'Unknown'),
+                'mac': bt_mgr.mac_address if bt_mgr else None,
+                'connected': client.status.get('bluetooth_connected', False),
+                'sink': getattr(client, 'bluetooth_sink_name', None),
+                'last_error': client.status.get('last_error'),
+            })
+        diag['devices'] = device_diag
+
+        return jsonify(diag)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+
+@app.route('/api/version')
+def api_version():
+    """Return git version information"""
+    cwd = os.path.dirname(os.path.abspath(__file__))
+    try:
+        git_sha = subprocess.run(
+            ['git', 'rev-parse', '--short', 'HEAD'],
+            capture_output=True, text=True, timeout=3, cwd=cwd
+        ).stdout.strip()
+        git_desc = subprocess.run(
+            ['git', 'describe', '--tags', '--always'],
+            capture_output=True, text=True, timeout=3, cwd=cwd
+        ).stdout.strip()
+        git_date = subprocess.run(
+            ['git', 'log', '-1', '--format=%ci'],
+            capture_output=True, text=True, timeout=3, cwd=cwd
+        ).stdout.strip()
+        return jsonify({
+            'version': git_desc or VERSION,
+            'git_sha': git_sha or 'unknown',
+            'built_at': (git_date.split(' ')[0] if git_date else BUILD_DATE),
+        })
+    except Exception:
+        return jsonify({'version': VERSION, 'git_sha': 'unknown', 'built_at': BUILD_DATE})
+
 
 def main():
     """Start the web interface"""
     port = int(os.getenv('WEB_PORT', 8080))
     logger.info(f"Starting web interface on port {port}")
     serve(app, host='0.0.0.0', port=port, threads=4)
+
 
 if __name__ == '__main__':
     main()

--- a/web_interface.py
+++ b/web_interface.py
@@ -147,7 +147,7 @@ HTML_TEMPLATE = """
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Sendspin Client</title>
+    <title>Sendspin BT Bridge</title>
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
         body {
@@ -373,7 +373,7 @@ HTML_TEMPLATE = """
 
     <!-- Header -->
     <div class="header">
-        <h1>&#127925; Sendspin Client</h1>
+        <h1>&#127925; Sendspin BT Bridge</h1>
         <div style="text-align:right;">
             <div class="version-info" id="version-display">
                 <div>{{ VERSION }}</div>

--- a/web_interface.py
+++ b/web_interface.py
@@ -100,6 +100,9 @@ def get_client_status_for(client):
         status['build_date'] = BUILD_DATE
         status['connected'] = client.process.poll() is None if client.process else False
         status['player_name'] = getattr(client, 'player_name', None)
+        status['listen_port'] = getattr(client, 'listen_port', None)
+        status['server_host'] = getattr(client, 'server_host', None)
+        status['server_port'] = getattr(client, 'server_port', None)
 
         bt_mgr = getattr(client, 'bt_manager', None)
         status['bluetooth_mac'] = bt_mgr.mac_address if bt_mgr else None
@@ -497,6 +500,7 @@ function buildDeviceCard(i) {
     card.innerHTML =
         '<div class="device-card-title" id="dname-' + i + '">Device ' + (i+1) + '</div>' +
         '<div class="device-mac" id="dmac-' + i + '"></div>' +
+        '<div class="device-url" id="durl-' + i + '" style="font-size:11px;color:#888;margin-bottom:8px;"></div>' +
         '<div class="device-rows">' +
           '<div>' +
             '<div class="status-label">Bluetooth</div>' +
@@ -538,6 +542,15 @@ function populateDeviceCard(i, dev) {
 
     var mac = dev.bluetooth_mac || '';
     document.getElementById('dmac-' + i).textContent = mac ? 'MAC: ' + mac : '';
+
+    var urlEl = document.getElementById('durl-' + i);
+    if (urlEl) {
+        if (dev.ip_address && dev.listen_port) {
+            urlEl.textContent = 'ws://' + dev.ip_address + ':' + dev.listen_port + '/sendspin';
+        } else {
+            urlEl.textContent = '';
+        }
+    }
 
     // Bluetooth
     var btInd   = document.getElementById('dbt-ind-' + i);

--- a/web_interface.py
+++ b/web_interface.py
@@ -1631,6 +1631,11 @@ def set_volume():
                 )
                 if r.returncode == 0:
                     client.status['volume'] = volume
+                    # Persist per-device volume so it survives restarts
+                    mac = getattr(getattr(client, 'bt_manager', None), 'mac_address', None)
+                    if mac:
+                        from sendspin_client import _save_device_volume
+                        _save_device_volume(mac, volume)
                     results.append({'player': getattr(client, 'player_name', '?'), 'ok': True})
                 else:
                     results.append({'player': getattr(client, 'player_name', '?'), 'ok': False})

--- a/web_interface.py
+++ b/web_interface.py
@@ -612,7 +612,7 @@ function populateDeviceCard(i, dev) {
 
     // Audio format
     var fmtEl = document.getElementById('daudiofmt-' + i);
-    if (fmtEl) fmtEl.textContent = dev.audio_format || '';
+    if (fmtEl) fmtEl.textContent = dev.audio_format ? 'Transport: ' + dev.audio_format : '';
 
     // Sync
     var syncEl = document.getElementById('dsync-' + i);

--- a/web_interface.py
+++ b/web_interface.py
@@ -401,8 +401,9 @@ HTML_TEMPLATE = """
             <div class="form-group">
                 <label>Timezone</label>
                 <div style="display:flex;gap:10px;align-items:center;">
-                    <input type="text" name="TZ" placeholder="Australia/Melbourne" style="flex:1;"
-                        oninput="updateTzPreview()">
+                    <input type="text" name="TZ" id="tz-input" placeholder="Australia/Melbourne" style="flex:1;"
+                        list="tz-list" autocomplete="off" oninput="updateTzPreview()">
+                    <datalist id="tz-list"></datalist>
                     <span id="tz-preview" class="tz-preview"></span>
                 </div>
             </div>
@@ -1048,6 +1049,46 @@ function updateTzPreview() {
 
 // Update TZ preview every second while panel is visible
 setInterval(updateTzPreview, 1000);
+
+// Populate TZ datalist from browser's IANA timezone database
+(function() {
+    var dl = document.getElementById('tz-list');
+    if (!dl) return;
+    var zones = [];
+    try {
+        zones = Intl.supportedValuesOf('timeZone');
+    } catch (_) {
+        // Fallback for older browsers — common zones
+        zones = [
+            'UTC','Africa/Cairo','Africa/Johannesburg','Africa/Lagos','Africa/Nairobi',
+            'America/Anchorage','America/Argentina/Buenos_Aires','America/Bogota',
+            'America/Chicago','America/Denver','America/Halifax','America/Los_Angeles',
+            'America/Mexico_City','America/New_York','America/Phoenix','America/Santiago',
+            'America/Sao_Paulo','America/Toronto','America/Vancouver',
+            'Asia/Bangkok','Asia/Colombo','Asia/Dubai','Asia/Hong_Kong','Asia/Jakarta',
+            'Asia/Jerusalem','Asia/Karachi','Asia/Kolkata','Asia/Kuala_Lumpur',
+            'Asia/Seoul','Asia/Shanghai','Asia/Singapore','Asia/Taipei','Asia/Tehran',
+            'Asia/Tokyo','Asia/Vladivostok','Asia/Yekaterinburg',
+            'Atlantic/Azores','Atlantic/Reykjavik',
+            'Australia/Adelaide','Australia/Brisbane','Australia/Darwin',
+            'Australia/Melbourne','Australia/Perth','Australia/Sydney',
+            'Europe/Amsterdam','Europe/Athens','Europe/Berlin','Europe/Brussels',
+            'Europe/Budapest','Europe/Copenhagen','Europe/Dublin','Europe/Helsinki',
+            'Europe/Istanbul','Europe/Kyiv','Europe/Lisbon','Europe/London',
+            'Europe/Madrid','Europe/Moscow','Europe/Oslo','Europe/Paris',
+            'Europe/Prague','Europe/Rome','Europe/Stockholm','Europe/Vienna',
+            'Europe/Warsaw','Europe/Zurich',
+            'Pacific/Auckland','Pacific/Fiji','Pacific/Honolulu','Pacific/Noumea',
+        ];
+    }
+    var frag = document.createDocumentFragment();
+    zones.forEach(function(tz) {
+        var opt = document.createElement('option');
+        opt.value = tz;
+        frag.appendChild(opt);
+    });
+    dl.appendChild(frag);
+}());
 
 // ---- Version ----
 

--- a/web_interface.py
+++ b/web_interface.py
@@ -232,7 +232,7 @@ HTML_TEMPLATE = """
         .config-section summary::-webkit-details-marker,
         .logs-section summary::-webkit-details-marker { display: none; }
         .config-section summary::before, .logs-section summary::before {
-            content: '\25B6';
+            content: '\\25B6';
             display: inline-block; font-size: 13px; margin-right: 8px;
             transition: transform 0.2s;
         }
@@ -345,7 +345,7 @@ HTML_TEMPLATE = """
         }
         .diag-section summary::-webkit-details-marker { display: none; }
         .diag-section summary::before {
-            content: '\25B6';
+            content: '\\25B6';
             display: inline-block; font-size: 13px; margin-right: 8px;
             transition: transform 0.2s;
         }

--- a/web_interface.py
+++ b/web_interface.py
@@ -36,7 +36,7 @@ CONFIG_FILE = CONFIG_DIR / 'config.json'
 
 # Default configuration
 DEFAULT_CONFIG = {
-    'SENDSPIN_NAME': 'Sendspin',
+
     'SENDSPIN_SERVER': 'auto',
     'BLUETOOTH_MAC': '',
     'BLUETOOTH_DEVICES': [],
@@ -481,10 +481,6 @@ HTML_TEMPLATE = """
     <details class="config-section" open>
         <summary>&#9881;&#65039; Configuration</summary>
         <form id="config-form">
-            <div class="form-group">
-                <label>Player Name Prefix</label>
-                <input type="text" name="SENDSPIN_NAME" id="cfg-sendspin-name" placeholder="Sendspin">
-            </div>
             <div class="form-group">
                 <label>Server (use &#8216;auto&#8217; for mDNS discovery)</label>
                 <input type="text" name="SENDSPIN_SERVER" required>
@@ -1327,7 +1323,7 @@ async function loadConfig() {
         var config = await resp.json();
 
         // Populate simple fields
-        ['SENDSPIN_NAME', 'SENDSPIN_SERVER', 'TZ'].forEach(function(key) {
+        ['SENDSPIN_SERVER', 'TZ'].forEach(function(key) {
             var input = document.querySelector('[name="' + key + '"]');
             if (input && config[key] !== undefined) input.value = config[key];
         });
@@ -1343,7 +1339,7 @@ async function loadConfig() {
             populateBtDeviceRows(devices);
         } else if (config.BLUETOOTH_MAC) {
             // Migrate single BLUETOOTH_MAC to table
-            addBtDeviceRow(config.SENDSPIN_NAME || '', config.BLUETOOTH_MAC, '');
+            addBtDeviceRow('', config.BLUETOOTH_MAC, '');
         }
     } catch (err) {
         console.error('Error loading config:', err);

--- a/web_interface.py
+++ b/web_interface.py
@@ -147,7 +147,7 @@ HTML_TEMPLATE = """
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Sendspin BT Bridge</title>
+    <title>Sendspin Bluetooth Bridge</title>
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
         body {
@@ -373,7 +373,7 @@ HTML_TEMPLATE = """
 
     <!-- Header -->
     <div class="header">
-        <h1>&#127925; Sendspin BT Bridge</h1>
+        <h1>&#127925; Sendspin Bluetooth Bridge</h1>
         <div style="text-align:right;">
             <div class="version-info" id="version-display">
                 <div>{{ VERSION }}</div>


### PR DESCRIPTION
## Summary

- Adds `_bt_remove_device(mac, adapter_mac)` helper that runs `bluetoothctl remove` in a background daemon thread (fire-and-forget)
- On `POST /api/config`, detects BLUETOOTH_DEVICES that were **deleted** or had their **adapter changed**, and calls the helper for each before writing the new config
- Uses the running `_clients` list to resolve the correct adapter MAC (`_adapter_select`) for each device

## Motivation

Changing a device's `adapter` field (e.g. `hci0` → `hci1`) left the old pairing on the original adapter. On restart, the service found the device "not paired" on the new adapter and entered a repeated failing pairing loop, requiring manual D-Bus and cache cleanup. This fix removes the stale pairing automatically when the config is saved.

## Test plan

- [ ] Add two devices, restart service, confirm both connect
- [ ] Change one device's adapter in UI → Save → check logs for `BT stack: removed <mac>`
- [ ] Restart → device should re-pair cleanly on new adapter (no "not paired" loop)
- [ ] Delete a device from config → Save → `bluetoothctl devices` should no longer show it as paired

🤖 Generated with [Claude Code](https://claude.com/claude-code)